### PR TITLE
Ensure correct playing state

### DIFF
--- a/conviva/src/main/java/com/bitmovin/analytics/conviva/ConvivaAnalytics.java
+++ b/conviva/src/main/java/com/bitmovin/analytics/conviva/ConvivaAnalytics.java
@@ -127,7 +127,7 @@ public class ConvivaAnalytics {
             createContentMetadata();
             sessionId = client.createSession(contentMetadata);
             setupPlayerStateManager();
-            Log.i(TAG, "[Player Event] Created SessionID - " + sessionId);
+            Log.d(TAG, "[Player Event] Created SessionID - " + sessionId);
             client.attachPlayer(sessionId, playerStateManager);
         } catch (ConvivaException e) {
             Log.e(TAG, e.getLocalizedMessage());
@@ -368,7 +368,7 @@ public class ConvivaAnalytics {
     private OnUnmutedListener onUnmutedListener = new OnUnmutedListener() {
         @Override
         public void onUnmuted(UnmutedEvent unmutedEvent) {
-            Log.d(TAG, "[Player Event] OnUnmoted");
+            Log.d(TAG, "[Player Event] OnUnmuted");
             customEvent(unmutedEvent);
         }
     };

--- a/conviva/src/main/java/com/bitmovin/analytics/conviva/ConvivaAnalytics.java
+++ b/conviva/src/main/java/com/bitmovin/analytics/conviva/ConvivaAnalytics.java
@@ -127,7 +127,7 @@ public class ConvivaAnalytics {
             createContentMetadata();
             sessionId = client.createSession(contentMetadata);
             setupPlayerStateManager();
-            Log.i(TAG, "Created SessionID - " + sessionId);
+            Log.i(TAG, "[Player Event] Created SessionID - " + sessionId);
             client.attachPlayer(sessionId, playerStateManager);
         } catch (ConvivaException e) {
             Log.e(TAG, e.getLocalizedMessage());
@@ -319,7 +319,7 @@ public class ConvivaAnalytics {
             new Handler().postDelayed(new Runnable() {
                 @Override
                 public void run() {
-                    Log.d(TAG, "OnSourceUnloaded");
+                    Log.d(TAG, "[Player Event] OnSourceUnloaded");
                     endConvivaSession();
                 }
             }, 100);
@@ -329,7 +329,7 @@ public class ConvivaAnalytics {
     private OnErrorListener onErrorListener = new OnErrorListener() {
         @Override
         public void onError(ErrorEvent errorEvent) {
-            Log.d(TAG, "OnError");
+            Log.d(TAG, "[Player Event] OnError");
             try {
                 ensureConvivaSessionIsCreatedAndInitialized();
 
@@ -345,7 +345,7 @@ public class ConvivaAnalytics {
     private OnWarningListener onWarningListener = new OnWarningListener() {
         @Override
         public void onWarning(WarningEvent warningEvent) {
-            Log.d(TAG, "OnWarning");
+            Log.d(TAG, "[Player Event] OnWarning");
             try {
                 ensureConvivaSessionIsCreatedAndInitialized();
 
@@ -360,7 +360,7 @@ public class ConvivaAnalytics {
     private OnMutedListener onMutedListener = new OnMutedListener() {
         @Override
         public void onMuted(MutedEvent mutedEvent) {
-            Log.d(TAG, "OnMuted");
+            Log.d(TAG, "[Player Event] OnMuted");
             customEvent(mutedEvent);
         }
     };
@@ -368,7 +368,7 @@ public class ConvivaAnalytics {
     private OnUnmutedListener onUnmutedListener = new OnUnmutedListener() {
         @Override
         public void onUnmuted(UnmutedEvent unmutedEvent) {
-            Log.d(TAG, "OnUnmoted");
+            Log.d(TAG, "[Player Event] OnUnmoted");
             customEvent(unmutedEvent);
         }
     };
@@ -377,7 +377,7 @@ public class ConvivaAnalytics {
     private OnPlayListener onPlayListener = new OnPlayListener() {
         @Override
         public void onPlay(PlayEvent playEvent) {
-            Log.d(TAG, "OnPlay");
+            Log.d(TAG, "[Player Event] OnPlay");
             ensureConvivaSessionIsCreatedAndInitialized();
             updateSession();
         }
@@ -386,7 +386,7 @@ public class ConvivaAnalytics {
     private OnPlayingListener onPlayingListener = new OnPlayingListener() {
         @Override
         public void onPlaying(PlayingEvent playingEvent) {
-            Log.d(TAG, "OnPlaying");
+            Log.d(TAG, "[Player Event] OnPlaying");
             transitionState(PlayerStateManager.PlayerState.PLAYING);
         }
     };
@@ -412,7 +412,7 @@ public class ConvivaAnalytics {
     private OnPlaybackFinishedListener onPlaybackFinishedListener = new OnPlaybackFinishedListener() {
         @Override
         public void onPlaybackFinished(PlaybackFinishedEvent playbackFinishedEvent) {
-            Log.d(TAG, "OnPlaybackFinished");
+            Log.d(TAG, "[Player Event] OnPlaybackFinished");
             transitionState(PlayerStateManager.PlayerState.STOPPED);
             endConvivaSession();
         }
@@ -421,7 +421,7 @@ public class ConvivaAnalytics {
     private OnStallStartedListener onStallStartedListener = new OnStallStartedListener() {
         @Override
         public void onStallStarted(StallStartedEvent stallStartedEvent) {
-            Log.d(TAG, "OnStallStarted");
+            Log.d(TAG, "[Player Event] OnStallStarted");
             transitionState(PlayerStateManager.PlayerState.BUFFERING);
         }
     };
@@ -458,7 +458,7 @@ public class ConvivaAnalytics {
                 // This also handles startTime feature. The same applies for onTimeShift.
                 return;
             }
-            Log.d(TAG, "OnSeek");
+            Log.d(TAG, "[Player Event] OnSeek");
             try {
                 playerStateManager.setPlayerSeekStart((int) seekEvent.getSeekTarget() * 1000);
             } catch (ConvivaException e) {
@@ -474,7 +474,7 @@ public class ConvivaAnalytics {
                 // See comment in onSeek
                 return;
             }
-            Log.d(TAG, "OnSeeked");
+            Log.d(TAG, "[Player Event] OnSeeked");
             try {
                 playerStateManager.setPlayerSeekEnd();
             } catch (ConvivaException e) {
@@ -526,7 +526,7 @@ public class ConvivaAnalytics {
     private OnVideoPlaybackQualityChangedListener onVideoPlaybackQualityChangedListener = new OnVideoPlaybackQualityChangedListener() {
         @Override
         public void onVideoPlaybackQualityChanged(VideoPlaybackQualityChangedEvent videoPlaybackQualityChangedEvent) {
-            Log.d(TAG, "OnVideoPlaybackQualityChanged");
+            Log.d(TAG, "[Player Event] OnVideoPlaybackQualityChanged");
             updateSession();
         }
     };


### PR DESCRIPTION
## Description
This pr is handling a use-case where no internet (bad internet) connectivity is available.

When this happens the event order from the SDK looks like following:
1) `onPlay`
2) `onStallStarted`
3) `onPaused`
4) `onStallEnded`
5) `onSourceUnloaded`
6) `onError (SourceError)`

For the `onPaused` and the `onStallEnded` there will be an `PlayerState` update reported. In both cases it would be `Paused` but this shouldn't be the case since the Playback never started. 
So the fix here is that we delay the `pause` and the `stallEnded` event tracking to give the `onError` the change to be handled first.

_The same behavior is already used for the `onSourceUnloaded` event in case of an error._