### PR TITLE
External session managing

### DIFF
--- a/conviva/src/main/java/com/bitmovin/analytics/conviva/BitmovinPlayerHelper.java
+++ b/conviva/src/main/java/com/bitmovin/analytics/conviva/BitmovinPlayerHelper.java
@@ -17,11 +17,18 @@ class BitmovinPlayerHelper {
 
     String getStreamType() {
         SourceItem sourceItem = player.getConfig().getSourceItem();
+        if (sourceItem == null) {
+            return null;
+        }
         return sourceItem.getType().name();
     }
 
     String getStreamUrl() {
         SourceItem sourceItem = player.getConfig().getSourceItem();
+
+        if (sourceItem == null) {
+            return null;
+        }
 
         switch (sourceItem.getType()) {
             case DASH:

--- a/conviva/src/main/java/com/bitmovin/analytics/conviva/ConvivaAnalytics.java
+++ b/conviva/src/main/java/com/bitmovin/analytics/conviva/ConvivaAnalytics.java
@@ -345,6 +345,7 @@ public class ConvivaAnalytics {
         } finally {
             sessionId = Client.NO_SESSION_KEY;
             playerStateManager = null;
+            metadataOverrides = new MetadataOverrides();
             Log.e(TAG, "Session ended");
         }
     }

--- a/conviva/src/main/java/com/bitmovin/analytics/conviva/ConvivaAnalytics.java
+++ b/conviva/src/main/java/com/bitmovin/analytics/conviva/ConvivaAnalytics.java
@@ -224,7 +224,7 @@ public class ConvivaAnalytics {
     public void reportPlaybackDeficiency(String message,
                                          Client.ErrorSeverity severity,
                                          Boolean endSession) {
-        if (!this.isSessionActive()) {
+        if (!isSessionActive()) {
             return;
         }
 

--- a/conviva/src/main/java/com/bitmovin/analytics/conviva/ConvivaAnalytics.java
+++ b/conviva/src/main/java/com/bitmovin/analytics/conviva/ConvivaAnalytics.java
@@ -145,10 +145,32 @@ public class ConvivaAnalytics {
         }
     }
 
+    /**
+     * Initializes a new conviva tracking session.
+     * <p>
+     * Warning: The integration can only be validated without external session managing. So when using this method we can
+     * no longer ensure that the session is managed at the correct time. Additional: Since some metadata attributes
+     * relies on the players source we can't ensure that all metadata attributes are present at session creation.
+     * Therefore it could be that there will be a 'ContentMetadata created late' issue after conviva validation.
+     * <p>
+     * If no source was loaded this method will throw an error.
+     */
     public void initializeSession() throws ConvivaAnalyticsException {
         initializeSession(null);
     }
 
+    /**
+     * Initializes a new conviva tracking session.
+     * <p>
+     * Warning: The integration can only be validated without external session managing. So when using this method we can
+     * no longer ensure that the session is managed at the correct time. Additional: Since some metadata attributes
+     * relies on the players source we can't ensure that all metadata attributes are present at session creation.
+     * Therefore it could be that there will be a 'ContentMetadata created late' issue after conviva validation.
+     *
+     * @param assetName Will be used as contentMetadata.assetName if no source was loaded before. This overrides the
+     *                  source assetName. If no source was loaded and no assetName is present this method will throw an
+     *                  error.
+     */
     public void initializeSession(String assetName) throws ConvivaAnalyticsException {
         if (isSessionActive()) {
             return;
@@ -165,6 +187,13 @@ public class ConvivaAnalytics {
         internalInitializeSession();
     }
 
+    /**
+     * Ends the current conviva tracking session.
+     * Results in a no-opt if there is no active session.
+     * <p>
+     * Warning: The integration can only be validated without external session managing.
+     * So when using this method we can no longer ensure that the session is managed at the correct time.
+     */
     public void endSession() {
         if (!isSessionActive()) {
             return;
@@ -177,7 +206,7 @@ public class ConvivaAnalytics {
      * Sends a custom deficiency event during playback to Conviva's Player Insight. If no session is active it will NOT
      * create one.
      *
-     * @param message Message which will be send to conviva
+     * @param message  Message which will be send to conviva
      * @param severity One of FATAL or WARNING
      */
     public void reportPlaybackDeficiency(String message, Client.ErrorSeverity severity) {
@@ -188,10 +217,10 @@ public class ConvivaAnalytics {
      * Sends a custom deficiency event during playback to Conviva's Player Insight. If no session is active it will NOT
      * create one.
      *
-     * @param message Message which will be send to conviva
-     * @param severity One of FATAL or WARNING
+     * @param message    Message which will be send to conviva
+     * @param severity   One of FATAL or WARNING
      * @param endSession Boolean flag if session should be closed after reporting the deficiency
-    */
+     */
     public void reportPlaybackDeficiency(String message,
                                          Client.ErrorSeverity severity,
                                          Boolean endSession) {

--- a/conviva/src/main/java/com/bitmovin/analytics/conviva/ConvivaAnalytics.java
+++ b/conviva/src/main/java/com/bitmovin/analytics/conviva/ConvivaAnalytics.java
@@ -58,8 +58,8 @@ import java.util.HashMap;
 import java.util.Map;
 
 public class ConvivaAnalytics {
-    class MetadataOverrides {
-        public String assetName;
+    private class MetadataOverrides {
+        String assetName;
     }
 
     private static final String TAG = "ConvivaAnalytics";

--- a/conviva/src/main/java/com/bitmovin/analytics/conviva/ConvivaAnalytics.java
+++ b/conviva/src/main/java/com/bitmovin/analytics/conviva/ConvivaAnalytics.java
@@ -206,7 +206,7 @@ public class ConvivaAnalytics {
      * Sends a custom deficiency event during playback to Conviva's Player Insight. If no session is active it will NOT
      * create one.
      *
-     * @param message  Message which will be send to conviva
+     * @param message Message which will be send to conviva
      * @param severity One of FATAL or WARNING
      */
     public void reportPlaybackDeficiency(String message, Client.ErrorSeverity severity) {
@@ -217,8 +217,8 @@ public class ConvivaAnalytics {
      * Sends a custom deficiency event during playback to Conviva's Player Insight. If no session is active it will NOT
      * create one.
      *
-     * @param message    Message which will be send to conviva
-     * @param severity   One of FATAL or WARNING
+     * @param message Message which will be send to conviva
+     * @param severity One of FATAL or WARNING
      * @param endSession Boolean flag if session should be closed after reporting the deficiency
      */
     public void reportPlaybackDeficiency(String message,

--- a/conviva/src/main/java/com/bitmovin/analytics/conviva/ConvivaAnalytics.java
+++ b/conviva/src/main/java/com/bitmovin/analytics/conviva/ConvivaAnalytics.java
@@ -168,8 +168,8 @@ public class ConvivaAnalytics {
      * Therefore it could be that there will be a 'ContentMetadata created late' issue after conviva validation.
      *
      * @param assetName Will be used as contentMetadata.assetName if no source was loaded before. This overrides the
-     *                  source assetName. If no source was loaded and no assetName is present this method will throw an
-     *                  error.
+     * source assetName. If no source was loaded and no assetName is present this method will throw an
+     * error.
      */
     public void initializeSession(String assetName) throws ConvivaAnalyticsException {
         if (isSessionActive()) {

--- a/conviva/src/main/java/com/bitmovin/analytics/conviva/ConvivaAnalyticsException.java
+++ b/conviva/src/main/java/com/bitmovin/analytics/conviva/ConvivaAnalyticsException.java
@@ -1,0 +1,7 @@
+package com.bitmovin.analytics.conviva;
+
+public class ConvivaAnalyticsException extends Exception {
+    public ConvivaAnalyticsException(String message) {
+        super(message);
+    }
+}


### PR DESCRIPTION
## Description
Since the integration can't detect what happen to playback if the app is send in background, this needs to be handed by the app developer itself.
This PR will introduce a `endSession` method where the conviva tracking session can be closed. This should be called when the app enters background.

For consistency and completeness also a `initializeSession` method is added.