### PR TITLE
Cleanup left over stuff from content metadata updating

### DIFF
--- a/ConvivaExampleApp/src/main/java/com/bitmovin/analytics/convivaanalyticsexample/MainActivity.java
+++ b/ConvivaExampleApp/src/main/java/com/bitmovin/analytics/convivaanalyticsexample/MainActivity.java
@@ -62,9 +62,7 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
         playerUIView.addView(bitmovinPlayerView);
 
         // Create your ConvivaConfiguration object
-        ConvivaConfiguration convivaConfig = new ConvivaConfiguration(
-                "ConvivaExample_BitmovinPlayer",
-                "ViewerId1");
+        ConvivaConfiguration convivaConfig = new ConvivaConfiguration();
 
         // Set only in debug mode
         if (gatewayUrl != null) {

--- a/conviva/src/main/java/com/bitmovin/analytics/conviva/ConvivaAnalytics.java
+++ b/conviva/src/main/java/com/bitmovin/analytics/conviva/ConvivaAnalytics.java
@@ -158,8 +158,8 @@ public class ConvivaAnalytics {
             return;
         }
 
-        if (bitmovinPlayer.getConfig().getSourceItem() == null
-                && bitmovinPlayer.getConfig().getSourceItem().getTitle() == null
+        if ((bitmovinPlayer.getConfig().getSourceItem() == null
+                || bitmovinPlayer.getConfig().getSourceItem().getTitle() == null)
                 && this.contentMetadataBuilder.getAssetName() == null) {
             throw new ConvivaAnalyticsException(
                     "AssetName is missing. Load player source (with Title) first or set assetName via updateContentMetadata"

--- a/conviva/src/main/java/com/bitmovin/analytics/conviva/ConvivaAnalytics.java
+++ b/conviva/src/main/java/com/bitmovin/analytics/conviva/ConvivaAnalytics.java
@@ -89,8 +89,11 @@ public class ConvivaAnalytics {
         SystemInterface androidSystemInterface = AndroidSystemInterfaceFactory.buildSecure(context);
         if (androidSystemInterface.isInitialized()) {
             SystemSettings systemSettings = new SystemSettings();
-            systemSettings.logLevel = SystemSettings.LogLevel.DEBUG;
             systemSettings.allowUncaughtExceptions = false;
+
+            if (config.isDebugLoggingEnabled()) {
+                systemSettings.logLevel = SystemSettings.LogLevel.DEBUG;
+            }
 
             SystemFactory androidSystemFactory = new SystemFactory(androidSystemInterface, systemSettings);
             ClientSettings clientSettings = new ClientSettings(customerKey);
@@ -155,9 +158,11 @@ public class ConvivaAnalytics {
             return;
         }
 
-        if (bitmovinPlayer.getConfig().getSourceItem() == null && this.contentMetadataBuilder.getAssetName() == null) {
+        if (bitmovinPlayer.getConfig().getSourceItem() == null
+                && bitmovinPlayer.getConfig().getSourceItem().getTitle() == null
+                && this.contentMetadataBuilder.getAssetName() == null) {
             throw new ConvivaAnalyticsException(
-                    "AssetName is missing. Load player source first or set assetName via updateContentMetadata"
+                    "AssetName is missing. Load player source (with Title) first or set assetName via updateContentMetadata"
             );
         }
 
@@ -181,11 +186,12 @@ public class ConvivaAnalytics {
 
     /**
      * Will update the contentMetadata which are tracked with conviva.
-     *
+     * <p>
      * If there is an active session only permitted values will be updated and propagated immediately.
      * If there is no active session the values will be set on session creation.
-     *
+     * <p>
      * Attributes set via this method will override automatic tracked once.
+     *
      * @param metadataOverrides MetadataOverrides attributes which will be used to track to conviva.
      * @see ContentMetadataBuilder for more information about permitted attributes
      */
@@ -329,7 +335,6 @@ public class ConvivaAnalytics {
     private void createContentMetadata() {
         SourceItem sourceItem = bitmovinPlayer.getConfig().getSourceItem();
 
-        contentMetadataBuilder.setApplicationName(config.getApplicationName());
         if (sourceItem != null) {
             contentMetadataBuilder.setAssetName(sourceItem.getTitle());
         }

--- a/conviva/src/main/java/com/bitmovin/analytics/conviva/ConvivaConfiguration.java
+++ b/conviva/src/main/java/com/bitmovin/analytics/conviva/ConvivaConfiguration.java
@@ -1,30 +1,11 @@
 package com.bitmovin.analytics.conviva;
 
-import java.util.HashMap;
-import java.util.Map;
-
 public class ConvivaConfiguration {
     private String gatewayUrl;
     private boolean debugLoggingEnabled;
-    private String applicationName = "Unknown (no config.applicationName set)";
-    private String viewerId;
-    private Map<String,String> customData = new HashMap<>();
 
     public ConvivaConfiguration() {
 
-    }
-
-    public ConvivaConfiguration(String applicationName, String viewerId) {
-        this.applicationName = applicationName;
-        this.viewerId = viewerId;
-    }
-
-    public Map<String, String> getCustomData() {
-        return customData;
-    }
-
-    public void setCustomData(Map<String, String> customData) {
-        this.customData = customData;
     }
 
     public String getGatewayUrl() {
@@ -41,21 +22,5 @@ public class ConvivaConfiguration {
 
     public void setDebugLoggingEnabled(boolean debugLoggingEnabled) {
         this.debugLoggingEnabled = debugLoggingEnabled;
-    }
-
-    public String getApplicationName() {
-        return applicationName;
-    }
-
-    public void setApplicationName(String applicationName) {
-        this.applicationName = applicationName;
-    }
-
-    public String getViewerId() {
-        return viewerId;
-    }
-
-    public void setViewerId(String viewerId) {
-        this.viewerId = viewerId;
     }
 }


### PR DESCRIPTION
## Description
The new way of content metadata overriding introduced in #14 left some outdated stuff behind.

## Fixes
- Cleanup `ConvivaConfiguration` (remove prior way to set some content metadata)
- Add missing check if source title is present when creating the session eternally