### PR TITLE
BITCON-31: App Loses Custom Metadata When Backgrounded

### DIFF
--- a/ConvivaExampleApp/src/main/java/com/bitmovin/analytics/convivaanalyticsexample/MainActivity.java
+++ b/ConvivaExampleApp/src/main/java/com/bitmovin/analytics/convivaanalyticsexample/MainActivity.java
@@ -8,6 +8,7 @@ import android.widget.LinearLayout;
 import android.widget.Switch;
 
 import com.bitmovin.analytics.conviva.ConvivaAnalytics;
+import com.bitmovin.analytics.conviva.ConvivaAnalyticsException;
 import com.bitmovin.analytics.conviva.ConvivaConfiguration;
 import com.bitmovin.analytics.conviva.MetadataOverrides;
 import com.bitmovin.player.BitmovinPlayer;
@@ -135,11 +136,17 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
     protected void onResume() {
         super.onResume();
         bitmovinPlayerView.onResume();
+        try {
+            convivaAnalytics.initializeSession();
+        } catch (ConvivaAnalyticsException e) {
+            e.printStackTrace();
+        }
     }
 
     @Override
     protected void onPause() {
-        bitmovinPlayerView.onPause();
+        bitmovinPlayerView.onStop();
+        convivaAnalytics.endSession();
         super.onPause();
     }
 
@@ -168,3 +175,4 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
         }
     }
 }
+

--- a/conviva/src/main/java/com/bitmovin/analytics/conviva/ConvivaAnalytics.java
+++ b/conviva/src/main/java/com/bitmovin/analytics/conviva/ConvivaAnalytics.java
@@ -67,6 +67,7 @@ public class ConvivaAnalytics {
     private ConvivaConfiguration config;
     private int sessionId = Client.NO_SESSION_KEY;
     private PlayerStateManager playerStateManager;
+    private MetadataOverrides metadataOverrides;
 
     // Wrapper to extract bitmovinPlayer helper methods
     private BitmovinPlayerHelper playerHelper;
@@ -197,6 +198,7 @@ public class ConvivaAnalytics {
      */
     public void updateContentMetadata(MetadataOverrides metadataOverrides) {
         this.contentMetadataBuilder.setOverrides(metadataOverrides);
+        this.metadataOverrides = metadataOverrides;
 
         if (!this.isSessionActive()) {
             Log.i(TAG, "[ ConvivaAnalytics ] no active session; Don't propagate content metadata to conviva.");
@@ -300,6 +302,9 @@ public class ConvivaAnalytics {
             createContentMetadata();
             sessionId = client.createSession(contentMetadataBuilder.build());
             setupPlayerStateManager();
+            if (metadataOverrides != null) {
+                updateContentMetadata(metadataOverrides);
+            }
             Log.d(TAG, "[Player Event] Created SessionID - " + sessionId);
             client.attachPlayer(sessionId, playerStateManager);
         } catch (ConvivaException e) {


### PR DESCRIPTION
- Conviva recommends the Conviva session be closed when an app is backgrounded & a new session should be created when the app is returned to the foreground. The ConvivaExampleApp was updated to reflect that flow.
- The metadetaOverrides (custom metadata) was not being stored for use in case of backgrounding in ConvivaAnalytics. I opted to store the metadataOverrides value & used it to update those values in Conviva when the app resumes if they are available. 

**Session 1:**
![Screen Shot 2020-12-22 at 12 51 55 PM](https://user-images.githubusercontent.com/22755354/102933223-1b90fa00-445f-11eb-9930-b11ff7d60d25.png)

**Session 2 (after app was backgrounded & resumed)**
![Screen Shot 2020-12-22 at 12 52 23 PM](https://user-images.githubusercontent.com/22755354/102933336-52ffa680-445f-11eb-8b9f-24e43d375eb2.png)
