### PR TITLE
Bugfix: remove BuildConfig.DEBUG check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+### [2.1.1]
+### Changed
+
+- Instead of checking BuildConfig.DEBUG, check whether config contains values to be set.
+
 ### [2.1.0]
 ### Added
 

--- a/ConvivaExampleApp/build.gradle
+++ b/ConvivaExampleApp/build.gradle
@@ -43,7 +43,7 @@ dependencies {
 
     implementation project(':conviva')
 
-    //implementation 'com.bitmovin.analytics:conviva:2.1.0'
+    //implementation 'com.bitmovin.analytics:conviva:2.1.1'
     //api 'com.conviva.sdk:conviva-core-sdk:4.0.20'
 
     implementation 'com.google.ads.interactivemedia.v3:interactivemedia:3.26.0' // only needed if ads are used:

--- a/ConvivaExampleApp/src/main/java/com/bitmovin/analytics/convivaanalyticsexample/MainActivity.java
+++ b/ConvivaExampleApp/src/main/java/com/bitmovin/analytics/convivaanalyticsexample/MainActivity.java
@@ -35,8 +35,8 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
     private Switch includeAdsSwitch;
 
     // Conviva
-    private static final String customerKey = "7e3b1e4d931a80408880c0847df5f5cc90c2c50f";
-    private static String gatewayUrl = "https://eyevinn-test.testonly.conviva.com"; // Set only in debug mode
+    private static final String customerKey = "YOUR-CUSTOMER-KEY";
+    private static String gatewayUrl; // Set only in debug mode
     private ConvivaAnalyticsIntegration convivaAnalyticsIntegration;
 
     // Player

--- a/ConvivaTestApp/build.gradle
+++ b/ConvivaTestApp/build.gradle
@@ -49,7 +49,7 @@ dependencies {
     implementation 'androidx.legacy:legacy-support-v4:1.0.0' // only needed if ads are used
 
     implementation project(path: ':conviva')
-    //implementation 'com.bitmovin.analytics:conviva:2.1.0'
+    //implementation 'com.bitmovin.analytics:conviva:2.1.1'
     //api 'com.conviva.sdk:conviva-core-sdk:4.0.20'
 
     implementation 'androidx.test:core-ktx:1.4.0'

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ And these lines to your main project
 ```
 dependencies {
   implementation 'com.conviva.sdk:conviva-core-sdk:4.0.20' // <-- conviva sdk
-  implementation 'com.bitmovin.analytics:conviva:2.1.0'
+  implementation 'com.bitmovin.analytics:conviva:2.1.1'
 }
 ```
 

--- a/conviva/build.gradle
+++ b/conviva/build.gradle
@@ -4,7 +4,7 @@ apply plugin: 'maven-publish'
 apply from: "../bitmovinpropertiesloader.gradle"
 
 def packageName = 'com.bitmovin.analytics'
-def libraryVersion = '2.1.0'
+def libraryVersion = '2.1.1'
 
 android {
     compileSdkVersion 30

--- a/conviva/src/main/java/com/bitmovin/analytics/conviva/ConvivaAnalyticsIntegration.java
+++ b/conviva/src/main/java/com/bitmovin/analytics/conviva/ConvivaAnalyticsIntegration.java
@@ -60,8 +60,7 @@ public class ConvivaAnalyticsIntegration {
         this.bitmovinPlayer = player;
         this.playerHelper = new BitmovinPlayerHelper(player);
         this.config = config;
-
-        if(BuildConfig.DEBUG) {
+        if(config.getGatewayUrl() != null || config.isDebugLoggingEnabled()) {
             Map<String, Object> settings = new HashMap<String, Object>();
             if (config.getGatewayUrl() != null) {
                 settings.put(ConvivaSdkConstants.GATEWAY_URL, config.getGatewayUrl());


### PR DESCRIPTION
Using the value of BuildConfig.DEBUG (to decide whether or not to add parameters when initialising Conviva) was causing problems. This PR removes that check and replaces it with a check on the config parameters that are to be added.