### PR TITLE
Ensure overridden asset name is used if it exists (on replay)

### DIFF
--- a/conviva/src/main/java/com/bitmovin/analytics/conviva/ConvivaAnalyticsIntegration.java
+++ b/conviva/src/main/java/com/bitmovin/analytics/conviva/ConvivaAnalyticsIntegration.java
@@ -294,8 +294,14 @@ public class ConvivaAnalyticsIntegration {
         Source source = bitmovinPlayer.getSource();
         if (source != null) {
             SourceConfig sourceConfig = source.getConfig();
+            String overriddenAssetName = metadataOverrides.getAssetName();
+
             if (sourceConfig != null) {
-                contentMetadataBuilder.setAssetName(sourceConfig.getTitle());
+                contentMetadataBuilder.setAssetName(overriddenAssetName != null ? overriddenAssetName : sourceConfig.getTitle());
+            } else {
+                if(overriddenAssetName != null) {
+                    contentMetadataBuilder.setAssetName(overriddenAssetName);
+                }
             }
         }
         this.buildDynamicContentMetadata();


### PR DESCRIPTION
With latest Conviva integration version, MetadataOverrides#assetName is forgotten upon replaying a certain asset. Steps to reproduce on ConvivaExampleApp are:

- Insert metadata.setAssetName("this is an asset name"); at l.99 in MainActivity.java
- Insert sourceConfig.setTitle("this is a source config title"); at l.119 in MainActivity.java
- Play sample video and wait until it finishes
- Observe Asset name in Conviva Touchstone to be this is an asset name
- Press the replay button on the player
- Observe Asset name in Conviva Touchstone to be this is a source config title

The fix was to check if an overridden asset name exists and if it does, use it in preference to the source config title.