### PR TITLE
Fix/report buffering on seek events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### [2.1.4]
-### Changed
+### Fixed
 
 - Send buffering event to Conviva on seek/timeshift
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+### [2.1.4]
+### Changed
+
+- Send buffering event to Conviva on seek/timeshift
+
 ### [2.1.3]
 ### Fixed
 

--- a/ConvivaTestApp/src/androidTest/java/com/bitmovin/analytics/conviva/testapp/PlaybackControlsTrackingTests.kt
+++ b/ConvivaTestApp/src/androidTest/java/com/bitmovin/analytics/conviva/testapp/PlaybackControlsTrackingTests.kt
@@ -77,6 +77,41 @@ class PlaybackControlsTrackingTests: TestBase() {
             clearMocks(videoAnalyticsMock!!)
             activity.bitmovinPlayer.seek(120.0)
         }
+        Thread.sleep(4000)
+        // verify seek tracking
+        activityScenario.onActivity { activity: MainActivity ->
+            verifyOrder {
+                videoAnalyticsMock?.reportPlaybackMetric(ConvivaSdkConstants.PLAYBACK.SEEK_STARTED,120000)
+                videoAnalyticsMock?.reportPlaybackMetric(ConvivaSdkConstants.PLAYBACK.PLAYER_STATE, ConvivaSdkConstants.PlayerState.BUFFERING)
+                videoAnalyticsMock?.reportPlaybackMetric(ConvivaSdkConstants.PLAYBACK.SEEK_ENDED)
+                videoAnalyticsMock?.reportPlaybackMetric(ConvivaSdkConstants.PLAYBACK.PLAYER_STATE, ConvivaSdkConstants.PlayerState.PLAYING)
+
+            }
+        }
+    }
+
+    @Test
+    fun vodSeekOnPause() {
+        // launch player with autoPlay enabled and initialize session
+        val metadata = defaultMetadataOverrides()
+        activityScenario = setupPlayerActivityForTest(autoPlay = false, metadata)
+
+        // initialize session and verify
+        initializeSession(activityScenario)
+
+        // verify session initialization
+        verifySessionInitialization(activityScenario)
+
+        // load source
+        loadSource(activityScenario, DEFAULT_DASH_VOD_SOURCE)
+        // verifyPlaying(activityScenario = activityScenario)
+
+        // seek
+        activityScenario.onActivity { activity: MainActivity ->
+            // Seek playback
+            clearMocks(videoAnalyticsMock!!)
+            activity.bitmovinPlayer.seek(120.0)
+        }
         Thread.sleep(2000)
         // verify seek tracking
         activityScenario.onActivity { activity: MainActivity ->
@@ -84,6 +119,8 @@ class PlaybackControlsTrackingTests: TestBase() {
                 videoAnalyticsMock?.reportPlaybackMetric(ConvivaSdkConstants.PLAYBACK.SEEK_STARTED,120000)
                 videoAnalyticsMock?.reportPlaybackMetric(ConvivaSdkConstants.PLAYBACK.PLAYER_STATE, ConvivaSdkConstants.PlayerState.BUFFERING)
                 videoAnalyticsMock?.reportPlaybackMetric(ConvivaSdkConstants.PLAYBACK.SEEK_ENDED)
+                videoAnalyticsMock?.reportPlaybackMetric(ConvivaSdkConstants.PLAYBACK.PLAYER_STATE, ConvivaSdkConstants.PlayerState.PAUSED)
+
             }
         }
     }
@@ -116,6 +153,8 @@ class PlaybackControlsTrackingTests: TestBase() {
                 videoAnalyticsMock?.reportPlaybackMetric(ConvivaSdkConstants.PLAYBACK.SEEK_STARTED,-1)
                 videoAnalyticsMock?.reportPlaybackMetric(ConvivaSdkConstants.PLAYBACK.PLAYER_STATE, ConvivaSdkConstants.PlayerState.BUFFERING)
                 videoAnalyticsMock?.reportPlaybackMetric(ConvivaSdkConstants.PLAYBACK.SEEK_ENDED)
+                videoAnalyticsMock?.reportPlaybackMetric(ConvivaSdkConstants.PLAYBACK.PLAYER_STATE, ConvivaSdkConstants.PlayerState.PLAYING)
+
             }
         }
     }

--- a/ConvivaTestApp/src/androidTest/java/com/bitmovin/analytics/conviva/testapp/PlaybackControlsTrackingTests.kt
+++ b/ConvivaTestApp/src/androidTest/java/com/bitmovin/analytics/conviva/testapp/PlaybackControlsTrackingTests.kt
@@ -91,7 +91,7 @@ class PlaybackControlsTrackingTests: TestBase() {
     }
 
     @Test
-    fun vodSeekOnPause() {
+    fun vodSeekWhenPaused() {
         // launch player with autoPlay enabled and initialize session
         val metadata = defaultMetadataOverrides()
         activityScenario = setupPlayerActivityForTest(autoPlay = false, metadata)
@@ -104,7 +104,6 @@ class PlaybackControlsTrackingTests: TestBase() {
 
         // load source
         loadSource(activityScenario, DEFAULT_DASH_VOD_SOURCE)
-        // verifyPlaying(activityScenario = activityScenario)
 
         // seek
         activityScenario.onActivity { activity: MainActivity ->
@@ -154,6 +153,39 @@ class PlaybackControlsTrackingTests: TestBase() {
                 videoAnalyticsMock?.reportPlaybackMetric(ConvivaSdkConstants.PLAYBACK.PLAYER_STATE, ConvivaSdkConstants.PlayerState.BUFFERING)
                 videoAnalyticsMock?.reportPlaybackMetric(ConvivaSdkConstants.PLAYBACK.SEEK_ENDED)
                 videoAnalyticsMock?.reportPlaybackMetric(ConvivaSdkConstants.PLAYBACK.PLAYER_STATE, ConvivaSdkConstants.PlayerState.PLAYING)
+
+            }
+        }
+    }
+
+    @Test
+    fun liveTimeshiftWhenPaused() {
+        // launch player with autoPlay enabled and initialize session
+        val metadata = defaultMetadataOverrides()
+        activityScenario = setupPlayerActivityForTest(autoPlay = false, metadata)
+
+        // initialize session and verify
+        initializeSession(activityScenario)
+
+        // verify session initialization
+        verifySessionInitialization(activityScenario)
+
+        // load source and verify
+        loadSource(activityScenario, DEFAULT_DASH_LIVE_SOURCE)
+
+        // timeshift
+        activityScenario.onActivity { activity: MainActivity ->
+            clearMocks(videoAnalyticsMock!!)
+            activity.bitmovinPlayer.timeShift(30.0)
+        }
+        Thread.sleep(2000)
+        // verify timeshift tracking
+        activityScenario.onActivity { activity: MainActivity ->
+            verifyOrder {
+                videoAnalyticsMock?.reportPlaybackMetric(ConvivaSdkConstants.PLAYBACK.SEEK_STARTED,-1)
+                videoAnalyticsMock?.reportPlaybackMetric(ConvivaSdkConstants.PLAYBACK.PLAYER_STATE, ConvivaSdkConstants.PlayerState.BUFFERING)
+                videoAnalyticsMock?.reportPlaybackMetric(ConvivaSdkConstants.PLAYBACK.SEEK_ENDED)
+                videoAnalyticsMock?.reportPlaybackMetric(ConvivaSdkConstants.PLAYBACK.PLAYER_STATE, ConvivaSdkConstants.PlayerState.PAUSED)
 
             }
         }

--- a/ConvivaTestApp/src/androidTest/java/com/bitmovin/analytics/conviva/testapp/PlaybackControlsTrackingTests.kt
+++ b/ConvivaTestApp/src/androidTest/java/com/bitmovin/analytics/conviva/testapp/PlaybackControlsTrackingTests.kt
@@ -82,11 +82,8 @@ class PlaybackControlsTrackingTests: TestBase() {
         activityScenario.onActivity { activity: MainActivity ->
             verifyOrder {
                 videoAnalyticsMock?.reportPlaybackMetric(ConvivaSdkConstants.PLAYBACK.SEEK_STARTED,120000)
-                // TODO - why is this behaviour different?
-                // videoAnalyticsMock?.reportPlaybackMetric(ConvivaSdkConstants.PLAYBACK.PLAYER_STATE, ConvivaSdkConstants.PlayerState.BUFFERING)
+                videoAnalyticsMock?.reportPlaybackMetric(ConvivaSdkConstants.PLAYBACK.PLAYER_STATE, ConvivaSdkConstants.PlayerState.BUFFERING)
                 videoAnalyticsMock?.reportPlaybackMetric(ConvivaSdkConstants.PLAYBACK.SEEK_ENDED)
-                // TODO - why is this behaviour different?
-                // videoAnalyticsMock?.reportPlaybackMetric(ConvivaSdkConstants.PLAYBACK.PLAYER_STATE, ConvivaSdkConstants.PlayerState.PLAYING)
             }
         }
     }
@@ -117,6 +114,7 @@ class PlaybackControlsTrackingTests: TestBase() {
         activityScenario.onActivity { activity: MainActivity ->
             verifyOrder {
                 videoAnalyticsMock?.reportPlaybackMetric(ConvivaSdkConstants.PLAYBACK.SEEK_STARTED,-1)
+                videoAnalyticsMock?.reportPlaybackMetric(ConvivaSdkConstants.PLAYBACK.PLAYER_STATE, ConvivaSdkConstants.PlayerState.BUFFERING)
                 videoAnalyticsMock?.reportPlaybackMetric(ConvivaSdkConstants.PLAYBACK.SEEK_ENDED)
             }
         }

--- a/ConvivaTestApp/src/androidTest/java/com/bitmovin/analytics/conviva/testapp/TestBase.kt
+++ b/ConvivaTestApp/src/androidTest/java/com/bitmovin/analytics/conviva/testapp/TestBase.kt
@@ -26,7 +26,6 @@ open class TestBase {
     var convivaAnalyticsMock: ConvivaAnalytics? = null
     lateinit var activityScenario: ActivityScenario<MainActivity>
 
-    var CONVIVA_SESSION_ID = 1
     val CUSTOM_EVENT_NAME = "CUSTOM_APPLICATION_EVENT"
     val CUSTOM_EVENT_ATTRIBUTES: HashMap<String, String> = mutableMapOf(
         "key" to "value"
@@ -41,6 +40,7 @@ open class TestBase {
 
     val PLAYER_TYPE = "Bitmovin Player Android"
     val PLAYER_VERSION = com.bitmovin.player.BuildConfig.VERSION_NAME
+    val TIMEOUT = 4000
 
     @Before
     fun setup() {
@@ -199,7 +199,7 @@ open class TestBase {
     fun initializeSession(activityScenario: ActivityScenario<MainActivity>) {
         activityScenario.onActivity { activity: MainActivity ->
             convivaAnalyticsIntegration?.initializeSession()
-            Thread.sleep(1000)
+            Thread.sleep(TIMEOUT.toLong())
         }
     }
 
@@ -229,7 +229,7 @@ open class TestBase {
         activityScenario.onActivity { activity: MainActivity ->
             activity.bitmovinPlayer.load(source)
         }
-        Thread.sleep(4000)
+        Thread.sleep(TIMEOUT.toLong())
     }
 
     fun playSource(activityScenario: ActivityScenario<MainActivity>) {

--- a/conviva/build.gradle
+++ b/conviva/build.gradle
@@ -4,7 +4,7 @@ apply plugin: 'maven-publish'
 apply from: "../bitmovinpropertiesloader.gradle"
 
 def packageName = 'com.bitmovin.analytics'
-def libraryVersion = '2.1.3'
+def libraryVersion = '2.1.4'
 
 android {
     compileSdkVersion 30

--- a/conviva/src/main/java/com/bitmovin/analytics/conviva/ConvivaAnalyticsIntegration.java
+++ b/conviva/src/main/java/com/bitmovin/analytics/conviva/ConvivaAnalyticsIntegration.java
@@ -553,18 +553,6 @@ public class ConvivaAnalyticsIntegration {
         public void onEvent(PlayerEvent.Seeked seekedEvent) {
             Log.d(TAG, "[Player Event] Seeked");
             setSeekEnd();
-            // Notify of seek buffering complete at this stage.
-            new Handler().postDelayed(new Runnable() {
-                @Override
-                public void run() {
-                    Log.d(TAG, "[Player Event] Update state after buffering");
-                    ConvivaSdkConstants.PlayerState state = ConvivaSdkConstants.PlayerState.PLAYING;
-                    if (bitmovinPlayer.isPaused()) {
-                        state = ConvivaSdkConstants.PlayerState.PAUSED;
-                    }
-                    transitionState(state);
-                }
-            }, 100);
         }
     };
 
@@ -595,6 +583,13 @@ public class ConvivaAnalyticsIntegration {
     public void setSeekEnd() {
         Log.d(TAG, "Sending seek end event");
         convivaVideoAnalytics.reportPlaybackMetric(ConvivaSdkConstants.PLAYBACK.SEEK_ENDED);
+        // Notify of seek buffering complete at this stage.
+        Log.d(TAG, "[Player Event] Update state after buffering");
+        ConvivaSdkConstants.PlayerState state = ConvivaSdkConstants.PlayerState.PAUSED;
+        if (bitmovinPlayer.isPlaying()) {
+            state = ConvivaSdkConstants.PlayerState.PLAYING;
+        }
+        transitionState(state);
     }
     // endregion
 

--- a/conviva/src/main/java/com/bitmovin/analytics/conviva/ConvivaAnalyticsIntegration.java
+++ b/conviva/src/main/java/com/bitmovin/analytics/conviva/ConvivaAnalyticsIntegration.java
@@ -544,7 +544,8 @@ public class ConvivaAnalyticsIntegration {
             Log.d(TAG, "[Player Event] Seek");
             setSeekStart((int) seekEvent.getTo().getTime() * 1000);
             // Conviva expect notification of buffering events on seek (typically there is always buffering)
-            transitionState(ConvivaSdkConstants.PlayerState.BUFFERING);        }
+            transitionState(ConvivaSdkConstants.PlayerState.BUFFERING);
+        }
     };
 
     private EventListener<PlayerEvent.Seeked> onSeekedListener = new EventListener<PlayerEvent.Seeked>() {
@@ -573,6 +574,8 @@ public class ConvivaAnalyticsIntegration {
             Log.d(TAG, "[Player Event] TimeShift");
             // According to conviva it is valid to pass -1 for seeking in live streams
             setSeekStart(-1);
+            // Conviva expect notification of buffering events on timeshift (typically there is always buffering)
+            transitionState(ConvivaSdkConstants.PlayerState.BUFFERING);
         }
     };
 


### PR DESCRIPTION
This is a fix for Conviva validation. We now send a buffering event on every timeshift/seek start event.