### PR TITLE
Allow for registering a new ConvivaAnalyticsIntegration to a reused Player

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 - New `release(Boolean releaseConvivaSdk)` function allows for registering a new `ConvivaAnalyticsIntegration` to a
-reused `Player`, when called with `releaseConvivaSdk = false`.
+reused `Player`, when called with `releaseConvivaSdk = false` on the previous instance.
 
 ## [2.1.4]
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Updated compileSdkVersion to 33
 
 ### Added
-- New `release(Boolean releaseConvivaSdk)` function allows for `ConvivaAnalyticsIntegration` to be reused, when called
-with `releaseConvivaSdk = false`.
+- New `release(Boolean releaseConvivaSdk)` function allows for registering a new `ConvivaAnalyticsIntegration` to a
+reused `Player`, when called with `releaseConvivaSdk = false`.
 
 ## [2.1.4]
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Updated Kotlin to 1.7.0
 - Updated compileSdkVersion to 33
 
+### Added
+- New `release(Boolean releaseConvivaSdk)` function allows for `ConvivaAnalyticsIntegration` to be reused, when called
+with `releaseConvivaSdk = false`.
+
 ## [2.1.4]
 ### Fixed
 

--- a/conviva/src/main/java/com/bitmovin/analytics/conviva/ConvivaAnalyticsIntegration.java
+++ b/conviva/src/main/java/com/bitmovin/analytics/conviva/ConvivaAnalyticsIntegration.java
@@ -155,8 +155,15 @@ public class ConvivaAnalyticsIntegration {
     }
 
     public void release() {
+        release(true);
+    }
+
+    public void release(Boolean releaseConvivaSdk) {
         convivaVideoAnalytics.release();
-        ConvivaAnalytics.release();
+        detachBitmovinEventListeners();
+        if (releaseConvivaSdk) {
+            ConvivaAnalytics.release();
+        }
     }
 
     /**
@@ -367,6 +374,42 @@ public class ConvivaAnalyticsIntegration {
         bitmovinPlayer.on(PlayerEvent.AdError.class, onAdErrorListener);
 
         bitmovinPlayer.on(PlayerEvent.VideoPlaybackQualityChanged.class, onVideoPlaybackQualityChangedListener);
+    }
+
+    private void detachBitmovinEventListeners() {
+        bitmovinPlayer.off(SourceEvent.Unloaded.class, onSourceUnloadedListener);
+        bitmovinPlayer.off(PlayerEvent.Error.class, onPlayerErrorListener);
+        bitmovinPlayer.off(SourceEvent.Error.class, onSourceErrorListener);
+        bitmovinPlayer.off(PlayerEvent.Warning.class, onPlayerWarningListener);
+        bitmovinPlayer.off(SourceEvent.Warning.class, onSourceWarningListener);
+
+        bitmovinPlayer.off(PlayerEvent.Muted.class, onMutedListener);
+        bitmovinPlayer.off(PlayerEvent.Unmuted.class, onUnmutedListener);
+
+        // Playback state events
+        bitmovinPlayer.off(PlayerEvent.Play.class, onPlayListener);
+        bitmovinPlayer.off(PlayerEvent.Playing.class, onPlayingListener);
+        bitmovinPlayer.off(PlayerEvent.Paused.class, onPausedListener);
+        bitmovinPlayer.off(PlayerEvent.StallEnded.class, onStallEndedListener);
+        bitmovinPlayer.off(PlayerEvent.StallStarted.class, onStallStartedListener);
+        bitmovinPlayer.off(PlayerEvent.PlaybackFinished.class, onPlaybackFinishedListener);
+
+        // Seek events
+        bitmovinPlayer.off(PlayerEvent.Seeked.class, onSeekedListener);
+        bitmovinPlayer.off(PlayerEvent.Seek.class, onSeekListener);
+
+        // Timeshift events
+        bitmovinPlayer.off(PlayerEvent.TimeShift.class, onTimeShiftListener);
+        bitmovinPlayer.off(PlayerEvent.TimeShifted.class, onTimeShiftedListener);
+
+        // Ad events
+        bitmovinPlayer.off(PlayerEvent.AdStarted.class, onAdStartedListener);
+        bitmovinPlayer.off(PlayerEvent.AdFinished.class, onAdFinishedListener);
+        bitmovinPlayer.off(PlayerEvent.AdSkipped.class, onAdSkippedListener);
+        bitmovinPlayer.off(PlayerEvent.AdError.class, onAdErrorListener);
+
+        bitmovinPlayer.off(PlayerEvent.VideoPlaybackQualityChanged.class,
+                onVideoPlaybackQualityChangedListener);
     }
 
     private synchronized void transitionState(ConvivaSdkConstants.PlayerState state) {


### PR DESCRIPTION
The current setup expects for 1 `ConvivaAnalyticsIntegration` instance to be used with 1 `BitmovinPlayer` instance.

To make it easier to get Conviva to track correctly in our implementation when changing video stream with 1 `BitmovinPlayer` instance (live channel zapping, play next, some use cases with chromecast) we'd like to use a new `ConvivaAnalyticsIntegration` for each new video stream.

The following changes were made:
- Add `ConvivaAnalyticsIntegration.release(Boolean releaseConvivaSdk)` function. Calling this function with `releaseConvivaSdk = false` prevents `ConvivaAnalytics.release()` from being called. Otherwise creating a new `ConvivaAnalyticsIntegration` right after this would result in a broken session ending in an EBVS.
- Detach Bitmovin player event listeners on `ConvivaAnalyticsIntegration.release(Boolean releaseConvivaSdk)`.
- Add `ConvivaAnalyticsIntegration.release()` convenience function mimicking current behaviour for backwards compatibility.

I couldn't get all tests to work, but I suspect this might be an issue with the 2 tests itself, report included.
![image](https://github.com/bitmovin/bitmovin-player-android-analytics-conviva/assets/22174865/5428e5c8-52a2-4a44-95a3-e52746ed121f)
[androidTests.zip](https://github.com/bitmovin/bitmovin-player-android-analytics-conviva/files/12040213/androidTests.zip)
