### PR TITLE
Feature/report play head time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
-## 2.3.0 - 2024-03-14
 ### Added
 - New `TimeChanged` callback for reporting Playhead to conviva playback metric. Calculates Live and Vod playback for report.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## 2.3.0 - 2024-03-14
+### Added
+- New `TimeChanged` callback for reporting Playhead to conviva playback metric. Calculates Live and Vod playback for report.
+
+### Changed
+- Updated conviva-core to 4.0.35
+
 ## 2.2.0 - 2023-07-18
 ### Added
 - New `release(Boolean releaseConvivaSdk)` function allows for registering a new `ConvivaAnalyticsIntegration` to a

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ allprojects {
 And these lines to your main project
 ```
 dependencies {
-  implementation 'com.conviva.sdk:conviva-core-sdk:4.0.20' // <-- conviva sdk
+  implementation 'com.conviva.sdk:conviva-core-sdk:4.0.35' // <-- conviva sdk
   implementation 'com.bitmovin.analytics:conviva:2.2.0'
 }
 ```

--- a/conviva/build.gradle
+++ b/conviva/build.gradle
@@ -4,7 +4,7 @@ apply plugin: 'maven-publish'
 apply from: "../bitmovinpropertiesloader.gradle"
 
 def packageName = 'com.bitmovin.analytics'
-def libraryVersion = '2.3.0'
+def libraryVersion = '2.2.0'
 
 android {
     compileSdkVersion rootProject.compileSdkVersion

--- a/conviva/build.gradle
+++ b/conviva/build.gradle
@@ -4,7 +4,7 @@ apply plugin: 'maven-publish'
 apply from: "../bitmovinpropertiesloader.gradle"
 
 def packageName = 'com.bitmovin.analytics'
-def libraryVersion = '2.2.0'
+def libraryVersion = '2.3.0'
 
 android {
     compileSdkVersion rootProject.compileSdkVersion
@@ -36,7 +36,7 @@ dependencies {
     testImplementation testingDependencies.junit
     androidTestImplementation testingDependencies.androidx_junit
     androidTestImplementation testingDependencies.androidx_espresso_core
-    api 'com.conviva.sdk:conviva-core-sdk:4.0.20'
+    api 'com.conviva.sdk:conviva-core-sdk:4.0.35'
     implementation bitmovinPlayerDependencies.bitmovinPlayer
     implementation 'org.apache.commons:commons-text:1.7'
 }

--- a/conviva/src/main/java/com/bitmovin/analytics/conviva/ConvivaAnalyticsIntegration.java
+++ b/conviva/src/main/java/com/bitmovin/analytics/conviva/ConvivaAnalyticsIntegration.java
@@ -1,7 +1,5 @@
 package com.bitmovin.analytics.conviva;
 
-import static com.conviva.sdk.ConvivaSdkConstants.PLAYBACK.PLAY_HEAD_TIME;
-
 import android.content.Context;
 import android.os.Handler;
 import android.util.Log;
@@ -410,6 +408,7 @@ public class ConvivaAnalyticsIntegration {
         bitmovinPlayer.off(PlayerEvent.AdFinished.class, onAdFinishedListener);
         bitmovinPlayer.off(PlayerEvent.AdSkipped.class, onAdSkippedListener);
         bitmovinPlayer.off(PlayerEvent.AdError.class, onAdErrorListener);
+        bitmovinPlayer.off(PlayerEvent.TimeChanged.class, onTimeChangedListener);
 
         bitmovinPlayer.off(PlayerEvent.VideoPlaybackQualityChanged.class,
                 onVideoPlaybackQualityChangedListener);
@@ -703,7 +702,7 @@ public class ConvivaAnalyticsIntegration {
 
     private void reportPlayHeadTime(long playerDurationMs) {
         if (isSessionActive) {
-            convivaVideoAnalytics.reportPlaybackMetric(PLAY_HEAD_TIME, playerDurationMs);
+            convivaVideoAnalytics.reportPlaybackMetric(ConvivaSdkConstants.PLAYBACK.PLAY_HEAD_TIME, playerDurationMs);
         }
     }
     // endregion

--- a/conviva/src/main/java/com/bitmovin/analytics/conviva/ConvivaAnalyticsIntegration.java
+++ b/conviva/src/main/java/com/bitmovin/analytics/conviva/ConvivaAnalyticsIntegration.java
@@ -687,7 +687,6 @@ public class ConvivaAnalyticsIntegration {
     private EventListener<PlayerEvent.TimeChanged> onTimeChangedListener = new EventListener<PlayerEvent.TimeChanged>() {
         @Override
         public void onEvent(PlayerEvent.TimeChanged timeChangedEvent) {
-            Log.d(TAG, "[Player Event] TimeChanged");
             if (bitmovinPlayer.isLive()) {
                 double playerTimeshiftMax = bitmovinPlayer.getMaxTimeShift();
                 double playerTimeshift = bitmovinPlayer.getTimeShift();

--- a/conviva/src/main/java/com/bitmovin/analytics/conviva/ConvivaAnalyticsIntegration.java
+++ b/conviva/src/main/java/com/bitmovin/analytics/conviva/ConvivaAnalyticsIntegration.java
@@ -374,7 +374,7 @@ public class ConvivaAnalyticsIntegration {
         bitmovinPlayer.on(PlayerEvent.AdFinished.class, onAdFinishedListener);
         bitmovinPlayer.on(PlayerEvent.AdSkipped.class, onAdSkippedListener);
         bitmovinPlayer.on(PlayerEvent.AdError.class, onAdErrorListener);
-        bitmovinPlayer.on(PlayerEvent.TimeChanged.class, onVideoTimeChangedListener);
+        bitmovinPlayer.on(PlayerEvent.TimeChanged.class, onTimeChangedListener);
 
         bitmovinPlayer.on(PlayerEvent.VideoPlaybackQualityChanged.class, onVideoPlaybackQualityChangedListener);
     }
@@ -684,13 +684,13 @@ public class ConvivaAnalyticsIntegration {
         }
     };
 
-    private EventListener<PlayerEvent.TimeChanged> onVideoTimeChangedListener = new EventListener<PlayerEvent.TimeChanged>() {
+    private EventListener<PlayerEvent.TimeChanged> onTimeChangedListener = new EventListener<PlayerEvent.TimeChanged>() {
         @Override
-        public void onEvent(PlayerEvent.TimeChanged videoTimeChangedEvent) {
-            Log.d(TAG, "[Player Event] VideoTimeChanged");
+        public void onEvent(PlayerEvent.TimeChanged timeChangedEvent) {
+            Log.d(TAG, "[Player Event] TimeChanged");
             if (bitmovinPlayer.isLive()) {
-                double playerTimeshiftMax = bitmovinPlayer.getTimeShift();
-                double playerTimeshift = bitmovinPlayer.getMaxTimeShift();
+                double playerTimeshiftMax = bitmovinPlayer.getMaxTimeShift();
+                double playerTimeshift = bitmovinPlayer.getTimeShift();
                 long playerDurationMs = -(Math.round(playerTimeshiftMax * 1000));
                 long playerPositionMs = playerDurationMs - -(Math.round(playerTimeshift * 1000));
                 reportPlayHeadTime(playerPositionMs);
@@ -702,7 +702,7 @@ public class ConvivaAnalyticsIntegration {
         }
     };
 
-    private void reportPlayHeadTime(Long playerDurationMs) {
+    private void reportPlayHeadTime(long playerDurationMs) {
         if (isSessionActive) {
             convivaVideoAnalytics.reportPlaybackMetric(PLAY_HEAD_TIME, playerDurationMs);
         }


### PR DESCRIPTION
A new value that is needed in Conviva to get a pass on validation is the playhead time. This can be useful for example in error reporting, to know in what second the user has an issue. 

The following changes were made:

- Add new `TimeChanged` callback for reporting Playhead to conviva playback metric. Calculates Live and Vod playback for reporting.
- Updated conviva-core to 4.0.35

Build has been validated by Conviva:
NLZIET Android 5.0 -  App Version 5.7.5: https://pulse.conviva.com/app/appmanager/apps/5389/28241 - #20. Playhead Time (PHT) Passed (https://touchstone-conviva.conviva.com/ui?client=209004308.1313293974.1027138199.1109187838&pub=0&before=1710772679.4021997&session=876273758)
NLZIET Android TV 5.0  App Version 5.7.5: https://pulse.conviva.com/app/appmanager/apps/5392/28242 - 1. Playhead Time (PHT): Pass (https://touchstone-conviva.conviva.com/ui?client=836067775.1698472106.1392489906.2042532197&session=1096631015&pub=0&before=1710771018.5019999)
NLZIET FireTV 5.0 - App Version 5.7.5: Playhead Time (PHT) for VOD : PASSED

Some tests for `./gradlew ConvivaTestApp:connectedAndroidTest` seem to fail. I included the report.
<img width="597" alt="image" src="https://github.com/bitmovin/bitmovin-player-android-analytics-conviva/assets/127963037/d112b17a-cc73-4b83-a7e8-d7e5bd46dc7c">
[androidTests.zip](https://github.com/bitmovin/bitmovin-player-android-analytics-conviva/files/14719223/androidTests.zip)
