### PR TITLE
Support additional standard device and content tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 - New `TimeChanged` callback for reporting Playhead to conviva playback metric. Calculates Live and Vod playback for report.
+- New `MetadataOverrides.setAdditionalStandardTags` that allows to set additional standard tags for the session. The List of tags can be found here: [Pre-defined Video and Content Metadata](https://pulse.conviva.com/learning-center/content/sensor_developer_center/sensor_integration/android/android_stream_sensor.htm#PredefinedVideoandContentMetadata)
 
 ### Changed
 - Updated conviva-core to 4.0.35

--- a/ConvivaExampleApp/src/main/java/com/bitmovin/analytics/convivaanalyticsexample/MainActivity.java
+++ b/ConvivaExampleApp/src/main/java/com/bitmovin/analytics/convivaanalyticsexample/MainActivity.java
@@ -87,18 +87,22 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
                 getApplicationContext(),
                 convivaConfig);
 
-
         MetadataOverrides metadata = new MetadataOverrides();
         metadata.setApplicationName("Bitmovin Android Conviva integration example app");
         metadata.setViewerId("awesomeViewerId");
-        Map<String, String> customInternTags = new HashMap<>();
-        customInternTags.put("contentType", "Episode");
-        metadata.setCustom(customInternTags);
+
+        Map<String, Object> standardTags = new HashMap<>();
+        standardTags.put("c3.cm.contentType", "VOD");
+        metadata.setAdditionalStandardTags(standardTags);
+
+        Map<String, String> customTags = new HashMap<>();
+        customTags.put("custom_tag", "Episode");
+        metadata.setCustom(customTags);
+
         convivaAnalyticsIntegration.updateContentMetadata(metadata);
 
         // load source using the created source configuration
         bitmovinPlayer.load(buildSourceConfiguration());
-
     }
 
     private PlayerConfig buildPlayerConfiguration() {
@@ -147,7 +151,7 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
     }
 
     @Override
-    protected void onDestroy() {    
+    protected void onDestroy() {
         bitmovinPlayerView.onDestroy();
         convivaAnalyticsIntegration.release();
         super.onDestroy();

--- a/README.md
+++ b/README.md
@@ -95,15 +95,20 @@ convivaConfig.setCustomData(customMapOfKeyValuePairs);
 
 #### Content Metadata handling
 
-If you want to override some content metadata attributes you can do so by adding the following:
+If you want to override some content metadata attributes or track additional custom or standard tags you can do so by adding the following:
 
 ```java
 MetadataOverrides metadata = new MetadataOverrides();
 metadata.setApplicationName("Bitmovin Android Conviva integration example app");
 metadata.setViewerId("awesomeViewerId");
-Map<String, String> customInternTags = new HashMap<>();
-customInternTags.put("contentType", "Episode");
-metadata.setCustom(customInternTags);
+
+Map<String, String> customTags = new HashMap<>();
+customTags.put("custom_tag", "value");
+metadata.setCustom(customTags);
+
+Map<String, Object> standardTags = new HashMap<>();
+standardTags.put("c3.cm.contentType", "VOD");
+metadata.setAdditionalStandardTags(standardTags);
 
 // …
 // Initialize ConvivaAnalyticsIntegration

--- a/README.md
+++ b/README.md
@@ -68,10 +68,8 @@ The following example create a ConvivaAnalyticsIntegration object and attaches a
 #### Basic Conviva Reporting
 
 ```java
-// Create your ConvivaConfiguration object
-ConvivaConfiguration convivaConfig = new ConvivaConfig(
-    "ConvivaExample_BitmovinPlayer",
-    "ViewerId1");
+// Create your ConvivaConfig object
+ConvivaConfig convivaConfig = new ConvivaConfig();
 
 // Create ConvivaAnalyticsIntegration
 convivaAnalyticsIntegration = new ConvivaAnalyticsIntegration(bitmovinPlayer, "YOUR-CUSTOMER-KEY", getApplicationContext(), convivaConfig);
@@ -87,9 +85,8 @@ bitmovinPlayer.load(source);
 
 #### Optional Configuration Parameters
 ```java
-
+convivaConfig.setGatewayUrl("YOUR_DEBUG_GATEWAY_URL");
 convivaConfig.setDebugLoggingEnabled(true);
-convivaConfig.setCustomData(customMapOfKeyValuePairs);
 
 ```
 
@@ -102,13 +99,13 @@ MetadataOverrides metadata = new MetadataOverrides();
 metadata.setApplicationName("Bitmovin Android Conviva integration example app");
 metadata.setViewerId("awesomeViewerId");
 
-Map<String, String> customTags = new HashMap<>();
-customTags.put("custom_tag", "value");
-metadata.setCustom(customTags);
-
 Map<String, Object> standardTags = new HashMap<>();
 standardTags.put("c3.cm.contentType", "VOD");
 metadata.setAdditionalStandardTags(standardTags);
+
+Map<String, String> customTags = new HashMap<>();
+customTags.put("custom_tag", "value");
+metadata.setCustom(customTags);
 
 // …
 // Initialize ConvivaAnalyticsIntegration

--- a/conviva/src/main/java/com/bitmovin/analytics/conviva/ContentMetadataBuilder.java
+++ b/conviva/src/main/java/com/bitmovin/analytics/conviva/ContentMetadataBuilder.java
@@ -1,10 +1,7 @@
 package com.bitmovin.analytics.conviva;
 
 import android.util.Log;
-
-import com.conviva.api.ContentMetadata;
 import com.conviva.sdk.ConvivaSdkConstants;
-
 import org.apache.commons.lang3.ObjectUtils;
 
 import java.util.HashMap;
@@ -47,7 +44,7 @@ class ContentMetadataBuilder {
     public Map<String, Object> build() {
 
         if (!playbackStarted) {
-            if(!contentInfo.containsKey(ConvivaSdkConstants.ASSET_NAME)) {
+            if (!contentInfo.containsKey(ConvivaSdkConstants.ASSET_NAME)) {
                 contentInfo.put(ConvivaSdkConstants.ASSET_NAME, getAssetName());
             }
 
@@ -60,34 +57,35 @@ class ContentMetadataBuilder {
             contentInfo.put(ConvivaSdkConstants.IS_LIVE, isLive);
 
             String applicationName = ObjectUtils.defaultIfNull(
-                metadataOverrides.getApplicationName(),
-                metadata.getApplicationName());
+                    metadataOverrides.getApplicationName(),
+                    metadata.getApplicationName());
             contentInfo.put(ConvivaSdkConstants.PLAYER_NAME, applicationName);
 
             Integer duration = ObjectUtils.defaultIfNull(
-                metadataOverrides.getDuration(),
-                metadata.getDuration());
+                    metadataOverrides.getDuration(),
+                    metadata.getDuration());
             Integer convivaDuration = duration != null ? duration : -1;
-            if(convivaDuration > 0) {
+            if (convivaDuration > 0) {
                 contentInfo.put(ConvivaSdkConstants.DURATION, convivaDuration);
             }
 
             contentInfo.putAll(getCustom());
+            contentInfo.putAll(getAdditionalStandardTags());
         }
 
         Integer frameRate = ObjectUtils.defaultIfNull(
                 metadataOverrides.getEncodedFrameRate(),
                 metadata.getEncodedFrameRate());
         contentInfo.put(ConvivaSdkConstants.ENCODED_FRAMERATE, frameRate != null ? frameRate : -1);
-    
+
         String defaultResource = ObjectUtils.defaultIfNull(
-                 metadataOverrides.getDefaultResource(),
-                 metadata.getDefaultResource());
+                metadataOverrides.getDefaultResource(),
+                metadata.getDefaultResource());
         contentInfo.put(ConvivaSdkConstants.DEFAULT_RESOURCE, defaultResource);
 
         String streamUrl = ObjectUtils.defaultIfNull(
-            metadataOverrides.getStreamUrl(),
-            metadata.getStreamUrl());
+                metadataOverrides.getStreamUrl(),
+                metadata.getStreamUrl());
         contentInfo.put(ConvivaSdkConstants.STREAM_URL, streamUrl);
 
         return contentInfo;
@@ -131,6 +129,22 @@ class ContentMetadataBuilder {
             customs.putAll(customOverrides);
         }
         return customs;
+    }
+
+    public void setAdditionalStandardTags(Map<String, Object> newValue) {
+        metadata.setAdditionalStandardTags(newValue);
+    }
+
+    public Map<String, Object> getAdditionalStandardTags() {
+        // merge internal and override metadata key-value pairs
+        // with override values having higher precedence
+        Map<String, Object> internalStandardTags = metadata.getAdditionalStandardTags();
+        Map<String, Object> additionalStandardTags = internalStandardTags != null ? internalStandardTags : new HashMap<>();
+        Map<String, Object> additionalStandardTagsOverrides = metadataOverrides.getAdditionalStandardTags();
+        if (additionalStandardTagsOverrides != null) {
+            additionalStandardTags.putAll(additionalStandardTagsOverrides);
+        }
+        return additionalStandardTags;
     }
 
     public void setDuration(Integer newValue) {

--- a/conviva/src/main/java/com/bitmovin/analytics/conviva/MetadataOverrides.java
+++ b/conviva/src/main/java/com/bitmovin/analytics/conviva/MetadataOverrides.java
@@ -14,6 +14,7 @@ public class MetadataOverrides {
     private String applicationName;
     private Map<String, String> custom;
     private Integer duration;
+    private Map<String, Object> additionalStandardTags;
 
     // Dynamic
     private Integer encodedFrameRate;
@@ -66,6 +67,18 @@ public class MetadataOverrides {
 
     public void setDuration(Integer duration) {
         this.duration = duration;
+    }
+
+    public Map<String, Object> getAdditionalStandardTags() {
+        return additionalStandardTags;
+    }
+
+    /**
+     * Standard Conviva tags that aren't covered by the other fields in this class.
+     * List of tags can be found here: <a href="https://pulse.conviva.com/learning-center/content/sensor_developer_center/sensor_integration/android/android_stream_sensor.htm#PredefinedVideoandContentMetadata">Pre-defined Video and Content Metadata</a>
+     */
+    public void setAdditionalStandardTags(Map<String, Object> additionalStandardTags) {
+        this.additionalStandardTags = additionalStandardTags;
     }
 
     public Integer getEncodedFrameRate() {


### PR DESCRIPTION
Conviva has a list of [predefined standard device and content tags ](https://pulse.conviva.com/learning-center/content/sensor_developer_center/sensor_integration/android/android_stream_sensor.htm#PredefinedVideoandContentMetadata)that this integration currently doesn't support reporting.

### Changes
- Add `MetadataOverrides.setAdditionalStandardTags` that allows to set additional standard tags for the session.
- Update the readme and example app
