### PR TITLE
Update conviva integration to latest android player version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Changed
+- Updated Bitmovin Player to `3.69.0`
+- Updated IMA SDK to `3.31.0`
+- Updated Kotlin to `1.9.23`
+- Updated conviva-core to `4.0.37`
+- Updated Gradle wrapper to `8.2` and AGP to `8.2.2`
+- Updated compile and target SDK version to `34`
 
 ## 2.3.0 - 2024-05-21
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Updated Gradle wrapper to `8.2` and AGP to `8.2.2`
 - Updated compile and target SDK version to `34`
 
+### Fixed
+- The pom file now also includes the `com.bitmovin.player` dependency which was missing before
+
 ## 2.3.0 - 2024-05-21
 ### Added
 - New `TimeChanged` callback for reporting Playhead to conviva playback metric. Calculates Live and Vod playback for report.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Updated Kotlin to `1.9.23`
 - Updated conviva-core to `4.0.37`
 - Updated Gradle wrapper to `8.2` and AGP to `8.2.2`
-- Updated compile and target SDK version to `34`
+- Increased minimum required `compileSdk` version to `34` 
+- Increased `compileSdk` and `targetSdkVersion` to `34`
 
 ### Fixed
 - The pom file now also includes the `com.bitmovin.player` dependency which was missing before

--- a/ConvivaExampleApp/build.gradle
+++ b/ConvivaExampleApp/build.gradle
@@ -1,7 +1,8 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion rootProject.compileSdkVersion
+    compileSdk rootProject.compileSdkVersion
+
     defaultConfig {
         applicationId "com.bitmovin.analytics.convivaanalyticsexample"
         minSdkVersion rootProject.minSdkVersion

--- a/ConvivaTestApp/build.gradle
+++ b/ConvivaTestApp/build.gradle
@@ -5,7 +5,6 @@ plugins {
 
 android {
     compileSdk rootProject.compileSdkVersion
-    buildToolsVersion "30.0.3"
 
     defaultConfig {
         applicationId "com.bitmovin.analytics.conviva.testapp"
@@ -38,7 +37,7 @@ android {
 }
 
 dependencies {
-    implementation 'androidx.appcompat:appcompat:1.2.0'
+    implementation 'androidx.appcompat:appcompat:1.6.1'
     implementation bitmovinPlayerDependencies.bitmovinPlayer
 
     implementation "com.google.ads.interactivemedia.v3:interactivemedia:$googleImaSdk" // only needed if ads are used:

--- a/ConvivaTestApp/build.gradle
+++ b/ConvivaTestApp/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 android {
-    compileSdkVersion rootProject.compileSdkVersion
+    compileSdk rootProject.compileSdkVersion
     buildToolsVersion "30.0.3"
 
     defaultConfig {

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ allprojects {
 And these lines to your main project
 ```
 dependencies {
-  implementation 'com.conviva.sdk:conviva-core-sdk:4.0.35' // <-- conviva sdk
+  implementation 'com.conviva.sdk:conviva-core-sdk:4.0.37' // <-- conviva sdk
   implementation 'com.bitmovin.analytics:conviva:2.3.0'
 }
 ```

--- a/build.gradle
+++ b/build.gradle
@@ -8,8 +8,8 @@ buildscript {
     }
     dependencies {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-        classpath 'com.android.tools.build:gradle:7.4.2'
-        classpath "org.jfrog.buildinfo:build-info-extractor-gradle:4.24.2"
+        classpath 'com.android.tools.build:gradle:8.2.2'
+        classpath "org.jfrog.buildinfo:build-info-extractor-gradle:4.33.1"
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlin_version = "1.7.0"
+    ext.kotlin_version = "1.9.23"
     repositories {
         mavenCentral()
         google()
@@ -18,8 +18,8 @@ buildscript {
 
 ext {
     minSdkVersion = 16
-    targetSdkVersion = 33
-    compileSdkVersion = 33
+    targetSdkVersion = 34
+    compileSdkVersion = 34
 }
 
 // Load dependencies

--- a/conviva/build.gradle
+++ b/conviva/build.gradle
@@ -59,22 +59,6 @@ publishing {
             afterEvaluate {
                 from components.release
             }
-
-            pom.withXml {
-                def dependenciesNode = asNode().appendNode('dependencies')
-
-                //Defining configuration names from which dependencies will be taken (debugCompile or releaseCompile and compile)
-                def configurationNames = ['api']
-
-                configurationNames.each { configurationName ->
-                    configurations[configurationName].allDependencies.each {
-                        def dependencyNode = dependenciesNode.appendNode('dependency')
-                        dependencyNode.appendNode('groupId', it.group)
-                        dependencyNode.appendNode('artifactId', it.name)
-                        dependencyNode.appendNode('version', it.version)
-                    }
-                }
-            }
         }
     }
 }
@@ -90,7 +74,7 @@ artifactory {
         }
         defaults {
             // Tell the Artifactory Plugin which artifacts should be published to Artifactory.
-            publications('aar')
+            publications('release')
             publishArtifacts = true
 
             // Properties to be attached to the published artifacts.

--- a/conviva/build.gradle
+++ b/conviva/build.gradle
@@ -39,14 +39,12 @@ android {
 }
 
 dependencies {
-    implementation fileTree(include: ['*.jar'], dir: 'libs')
-    implementation 'androidx.appcompat:appcompat:1.6.1'
+    api 'com.conviva.sdk:conviva-core-sdk:4.0.37'
+    implementation bitmovinPlayerDependencies.bitmovinPlayer
+
     testImplementation testingDependencies.junit
     androidTestImplementation testingDependencies.androidx_junit
     androidTestImplementation testingDependencies.androidx_espresso_core
-    api 'com.conviva.sdk:conviva-core-sdk:4.0.37'
-    implementation bitmovinPlayerDependencies.bitmovinPlayer
-    implementation 'org.apache.commons:commons-text:1.10.0'
 }
 
 publishing {

--- a/conviva/build.gradle
+++ b/conviva/build.gradle
@@ -7,7 +7,7 @@ def packageName = 'com.bitmovin.analytics'
 def libraryVersion = '2.2.0'
 
 android {
-    compileSdkVersion rootProject.compileSdkVersion
+    compileSdk rootProject.compileSdkVersion
 
     defaultConfig {
         minSdkVersion rootProject.minSdkVersion
@@ -26,6 +26,9 @@ android {
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
+    }
+    buildFeatures {
+        buildConfig true
     }
     namespace 'com.bitmovin.analytics.conviva'
 }

--- a/conviva/build.gradle
+++ b/conviva/build.gradle
@@ -7,6 +7,7 @@ def packageName = 'com.bitmovin.analytics'
 def libraryVersion = '2.2.0'
 
 android {
+    namespace 'com.bitmovin.analytics.conviva'
     compileSdk rootProject.compileSdkVersion
 
     defaultConfig {
@@ -30,29 +31,34 @@ android {
     buildFeatures {
         buildConfig true
     }
-    namespace 'com.bitmovin.analytics.conviva'
+    publishing {
+        singleVariant("release") {
+            withSourcesJar()
+        }
+    }
 }
 
 dependencies {
     implementation fileTree(include: ['*.jar'], dir: 'libs')
-    implementation 'androidx.appcompat:appcompat:1.2.0'
+    implementation 'androidx.appcompat:appcompat:1.6.1'
     testImplementation testingDependencies.junit
     androidTestImplementation testingDependencies.androidx_junit
     androidTestImplementation testingDependencies.androidx_espresso_core
-    api 'com.conviva.sdk:conviva-core-sdk:4.0.35'
+    api 'com.conviva.sdk:conviva-core-sdk:4.0.37'
     implementation bitmovinPlayerDependencies.bitmovinPlayer
-    implementation 'org.apache.commons:commons-text:1.7'
+    implementation 'org.apache.commons:commons-text:1.10.0'
 }
 
 publishing {
     publications {
-        aar(MavenPublication) {
+        release(MavenPublication) {
             groupId packageName
             version = libraryVersion
             artifactId project.getName()
 
-            // Tell maven to prepare the generated "*.aar" file for publishing
-            artifact("$buildDir/outputs/aar/${project.getName()}-release.aar")
+            afterEvaluate {
+                from components.release
+            }
 
             pom.withXml {
                 def dependenciesNode = asNode().appendNode('dependencies')

--- a/conviva/src/main/java/com/bitmovin/analytics/conviva/BitmovinPlayerHelper.java
+++ b/conviva/src/main/java/com/bitmovin/analytics/conviva/BitmovinPlayerHelper.java
@@ -1,6 +1,5 @@
 package com.bitmovin.analytics.conviva;
 
-import androidx.annotation.Nullable;
 import com.bitmovin.player.api.Player;
 
 class BitmovinPlayerHelper {
@@ -14,7 +13,6 @@ class BitmovinPlayerHelper {
         return Player.getSdkVersion();
     }
 
-    @Nullable
     String getStreamType() {
         if (player.getSource() == null) {
             return null;
@@ -23,7 +21,6 @@ class BitmovinPlayerHelper {
         }
     }
 
-    @Nullable
     String getStreamUrl() {
         if (player.getSource() == null) {
             return null;

--- a/conviva/src/main/java/com/bitmovin/analytics/conviva/BitmovinPlayerHelper.java
+++ b/conviva/src/main/java/com/bitmovin/analytics/conviva/BitmovinPlayerHelper.java
@@ -1,5 +1,6 @@
 package com.bitmovin.analytics.conviva;
 
+import androidx.annotation.Nullable;
 import com.bitmovin.player.api.Player;
 
 class BitmovinPlayerHelper {
@@ -13,16 +14,18 @@ class BitmovinPlayerHelper {
         return Player.getSdkVersion();
     }
 
+    @Nullable
     String getStreamType() {
-        if (player.getSource() == null || player.getSource().getConfig() == null) {
+        if (player.getSource() == null) {
             return null;
         } else {
             return player.getSource().getConfig().getType().name();
         }
     }
 
+    @Nullable
     String getStreamUrl() {
-        if (player.getSource() == null || player.getSource().getConfig() == null) {
+        if (player.getSource() == null) {
             return null;
         } else {
             return player.getSource().getConfig().getUrl();

--- a/conviva/src/main/java/com/bitmovin/analytics/conviva/ContentMetadataBuilder.java
+++ b/conviva/src/main/java/com/bitmovin/analytics/conviva/ContentMetadataBuilder.java
@@ -2,8 +2,6 @@ package com.bitmovin.analytics.conviva;
 
 import android.util.Log;
 import com.conviva.sdk.ConvivaSdkConstants;
-import org.apache.commons.lang3.ObjectUtils;
-
 import java.util.HashMap;
 import java.util.Map;
 

--- a/conviva/src/main/java/com/bitmovin/analytics/conviva/ConvivaAnalyticsIntegration.java
+++ b/conviva/src/main/java/com/bitmovin/analytics/conviva/ConvivaAnalyticsIntegration.java
@@ -114,9 +114,7 @@ public class ConvivaAnalyticsIntegration {
      * If no source was loaded this method will throw an error.
      */
     public void initializeSession() throws ConvivaAnalyticsException {
-        if ((bitmovinPlayer.getSource() == null ||
-                bitmovinPlayer.getSource().getConfig() == null
-                || bitmovinPlayer.getSource().getConfig().getTitle() == null)
+        if ((bitmovinPlayer.getSource() == null || bitmovinPlayer.getSource().getConfig().getTitle() == null)
                 && this.contentMetadataBuilder.getAssetName() == null) {
             throw new ConvivaAnalyticsException(
                     "AssetName is missing. Load player source (with Title) first or set assetName via updateContentMetadata"
@@ -300,13 +298,7 @@ public class ConvivaAnalyticsIntegration {
             SourceConfig sourceConfig = source.getConfig();
             String overriddenAssetName = metadataOverrides != null ? metadataOverrides.getAssetName() : null;
 
-            if (sourceConfig != null) {
-                contentMetadataBuilder.setAssetName(overriddenAssetName != null ? overriddenAssetName : sourceConfig.getTitle());
-            } else {
-                if(overriddenAssetName != null) {
-                    contentMetadataBuilder.setAssetName(overriddenAssetName);
-                }
-            }
+            contentMetadataBuilder.setAssetName(overriddenAssetName != null ? overriddenAssetName : sourceConfig.getTitle());
         }
         this.buildDynamicContentMetadata();
     }

--- a/conviva/src/main/java/com/bitmovin/analytics/conviva/ObjectUtils.java
+++ b/conviva/src/main/java/com/bitmovin/analytics/conviva/ObjectUtils.java
@@ -1,0 +1,7 @@
+package com.bitmovin.analytics.conviva;
+
+/*package*/ class ObjectUtils {
+    public static <T> T defaultIfNull(T object, T defaultValue) {
+        return object != null ? object : defaultValue;
+    }
+}

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,6 +1,6 @@
 ext {
-    bitmovinPlayerVersion = '3.39.0'
-    googleImaSdk = '3.29.0'
+    bitmovinPlayerVersion = '3.69.0'
+    googleImaSdk = '3.31.0'
     googlePlayAdsIdentifier = '18.0.1'
 
     bitmovinPlayerDependencies = [

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Tue Oct 12 15:36:49 CEST 2021
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.2-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
## Problem
Bitmovin player version is out of date. To update to the latest version also other dependencies had to be update, see the full list in the changelog.

With gradle update to `8.x` some of the AGP api has been updated, most notably publishing. The main difference is that we now also ship sources jar, which I find a much better development user experience. I was also able to remove some legacy  publishing configuration.

This PR also removes unneeded dependencies in the `conviva` module: https://github.com/bitmovin/bitmovin-player-android-analytics-conviva/pull/59/commits/af789ba8256684d325e741230006910689aae02f

## Testing
 I created a test release `2.3.1-rc.3`, available in `libs-release-local` folder, looks like everything still works as expected.
