### PR TITLE
Ad lifecycle reporting for ads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Added
+- Ad analytics for ad event reporting
+
 ### Changed
 - Updated Bitmovin Player to `3.69.0`
 - Updated IMA SDK to `3.31.0`
@@ -13,6 +16,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Updated Gradle wrapper to `8.2` and AGP to `8.2.2`
 - Increased minimum required `compileSdk` version to `34` 
 - Increased `compileSdk` and `targetSdkVersion` to `34`
+- Ad break started and ended is now reported in `PlayerEvent.AdBreakStarted` and `PlayerEvent.AdBreakFinished`
+
+### Removed
+- Custom event for `AdSkipped` and `AdError`. Replaced by Conviva build in tracking
 
 ### Fixed
 - The pom file now also includes the `com.bitmovin.player` dependency which was missing before

--- a/conviva/src/main/java/com/bitmovin/analytics/conviva/ConvivaAnalyticsIntegration.java
+++ b/conviva/src/main/java/com/bitmovin/analytics/conviva/ConvivaAnalyticsIntegration.java
@@ -410,6 +410,8 @@ public class ConvivaAnalyticsIntegration {
         bitmovinPlayer.off(PlayerEvent.TimeShifted.class, onTimeShiftedListener);
 
         // Ad events
+        bitmovinPlayer.off(PlayerEvent.AdBreakStarted.class, onAdBreakStarted);
+        bitmovinPlayer.off(PlayerEvent.AdBreakFinished.class, onAdBreakFinished);
         bitmovinPlayer.off(PlayerEvent.AdStarted.class, onAdStartedListener);
         bitmovinPlayer.off(PlayerEvent.AdFinished.class, onAdFinishedListener);
         bitmovinPlayer.off(PlayerEvent.AdSkipped.class, onAdSkippedListener);

--- a/conviva/src/main/java/com/bitmovin/analytics/conviva/ConvivaAnalyticsIntegration.java
+++ b/conviva/src/main/java/com/bitmovin/analytics/conviva/ConvivaAnalyticsIntegration.java
@@ -593,6 +593,9 @@ public class ConvivaAnalyticsIntegration {
         @Override
         public void onEvent(PlayerEvent.AdBreakStarted adBreakStarted) {
             Log.d(TAG, "[Player Event] AdBreakStarted");
+            // For pre-roll ads there is no `PlayerEvent.Play` before the `PlayerEvent.AdBreakStarted`
+            // which means we need to make sure the session is correctly initialized.
+            ensureConvivaSessionIsCreatedAndInitialized();
             convivaVideoAnalytics.reportAdBreakStarted(ConvivaSdkConstants.AdPlayer.CONTENT, ConvivaSdkConstants.AdType.CLIENT_SIDE);
         }
     };


### PR DESCRIPTION
There is currently no ad related events reported through `ConvivaAdAnalytics` which results in lacking ad metrics and metadata.

This PR introduces the ad lifecycle using the `ConvivaAdAnalytics`  but does not yet track all ad related metrics and only limited metadata. This will be done in a follow-up PR.

⚠️ Running the sample app some not ad related integration errors are shown in touchstone. This was already the case before this PR and is not related to the changes.