### PR TITLE
Report additional ad metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Ad analytics for ad event reporting
 
 ### Changed
-- Updated Bitmovin Player to `3.69.0`
+- Updated Bitmovin Player to `3.71.0`
 - Updated IMA SDK to `3.31.0`
 - Updated Kotlin to `1.9.23`
 - Updated conviva-core to `4.0.37`

--- a/ConvivaExampleApp/src/main/java/com/bitmovin/analytics/convivaanalyticsexample/MainActivity.java
+++ b/ConvivaExampleApp/src/main/java/com/bitmovin/analytics/convivaanalyticsexample/MainActivity.java
@@ -103,6 +103,8 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
         customTags.put("custom_tag", "Episode");
         metadata.setCustom(customTags);
 
+        metadata.setImaSdkVersion("3.31.0");
+
         convivaAnalyticsIntegration.updateContentMetadata(metadata);
 
         // load source using the created source configuration

--- a/conviva/src/main/java/com/bitmovin/analytics/conviva/ConvivaAnalyticsIntegration.java
+++ b/conviva/src/main/java/com/bitmovin/analytics/conviva/ConvivaAnalyticsIntegration.java
@@ -635,7 +635,7 @@ public class ConvivaAnalyticsIntegration {
         adInfo.put("c3.ad.technology", "Client Side");
         if (adStartedEvent.getClientType() == AdSourceType.Ima) {
             adInfo.put(ConvivaSdkConstants.FRAMEWORK_NAME, "Google IMA SDK");
-            //tags.put(ConvivaSdkConstants.FRAMEWORK_VERSION, "3.31.0");// todo better way to provide version?
+            adInfo.put(ConvivaSdkConstants.FRAMEWORK_VERSION, "NA");
         } else {
             adInfo.put(ConvivaSdkConstants.FRAMEWORK_NAME, "Bitmovin");
             adInfo.put(ConvivaSdkConstants.FRAMEWORK_VERSION, playerHelper.getSdkVersionString());

--- a/conviva/src/main/java/com/bitmovin/analytics/conviva/ConvivaAnalyticsIntegration.java
+++ b/conviva/src/main/java/com/bitmovin/analytics/conviva/ConvivaAnalyticsIntegration.java
@@ -635,7 +635,10 @@ public class ConvivaAnalyticsIntegration {
         adInfo.put("c3.ad.technology", "Client Side");
         if (adStartedEvent.getClientType() == AdSourceType.Ima) {
             adInfo.put(ConvivaSdkConstants.FRAMEWORK_NAME, "Google IMA SDK");
-            adInfo.put(ConvivaSdkConstants.FRAMEWORK_VERSION, "NA");
+            adInfo.put(
+                    ConvivaSdkConstants.FRAMEWORK_VERSION,
+                    metadataOverrides.getImaSdkVersion() != null ? metadataOverrides.getImaSdkVersion() : "NA"
+            );
         } else {
             adInfo.put(ConvivaSdkConstants.FRAMEWORK_NAME, "Bitmovin");
             adInfo.put(ConvivaSdkConstants.FRAMEWORK_VERSION, playerHelper.getSdkVersionString());

--- a/conviva/src/main/java/com/bitmovin/analytics/conviva/MetadataOverrides.java
+++ b/conviva/src/main/java/com/bitmovin/analytics/conviva/MetadataOverrides.java
@@ -20,6 +20,7 @@ public class MetadataOverrides {
     private Integer encodedFrameRate;
     private String defaultResource;
     private String streamUrl;
+    private String imaSdkVersion;
 
     public String getAssetName() {
         return assetName;
@@ -103,5 +104,17 @@ public class MetadataOverrides {
 
     public void setStreamUrl(String streamUrl) {
         this.streamUrl = streamUrl;
+    }
+
+    public String getImaSdkVersion() {
+        return imaSdkVersion;
+    }
+
+    /**
+     * Set the IMA SDK version to be tracked with client side ads of type
+     * {@link com.bitmovin.player.api.advertising.AdSourceType#Ima}.
+     */
+    public void setImaSdkVersion(String imaSdkVersion) {
+        this.imaSdkVersion = imaSdkVersion;
     }
 }

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,5 +1,5 @@
 ext {
-    bitmovinPlayerVersion = '3.69.0'
+    bitmovinPlayerVersion = '3.71.0'
     googleImaSdk = '3.31.0'
     googlePlayAdsIdentifier = '18.0.1'
 


### PR DESCRIPTION
## Problem
The current integration does not report sufficient ad metadata to the `ConvivaAdAnalytics`.

## Changes
Report ad metadata for client side ads reported through events on the Bitmovin Player.
To support additional ad wrapper wrapper information reporting the Bitmovin Player version is updated to `3.71.0`. 
As there is no known way of retrieving the Google IMA SDK version at runtime it has to be supplied in the `MetadataOverrides` if it should be tracked. Should we discover a way to retrieve the current version we can improve on the approach.

## 📚 Related PR's
- 📗 #62
- 📙 #63 
- 📒 #64 
