### PR TITLE
Increase `minSdkVersion` to 19

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Increased minimum required `compileSdk` version to `34` 
 - Increased `compileSdk` and `targetSdkVersion` to `34`
 - Ad break started and ended is now reported in `PlayerEvent.AdBreakStarted` and `PlayerEvent.AdBreakFinished`
+- Increased the `minSdkVersion` to 19
 
 ### Removed
 - Custom event for `AdSkipped` and `AdError`. Replaced by Conviva build in tracking

--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ buildscript {
 }
 
 ext {
-    minSdkVersion = 16
+    minSdkVersion = 19
     targetSdkVersion = 34
     compileSdkVersion = 34
 }


### PR DESCRIPTION
## Problem
Bitmovin Player version `3.71.0` requires a `minSdkVersion` of `19`.

## Change
Raise minSdkVersion to 19