### PR TITLE
Fix potential exception when determining the IMA SDK version on ad start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+
+### Fixed
+- Potential exception when determining the IMA SDK version on ad start
+
 ## 2.4.0 - 2024-06-06
 ### Added
 - Ad analytics for ad event reporting

--- a/conviva/src/main/java/com/bitmovin/analytics/conviva/ConvivaAnalyticsIntegration.java
+++ b/conviva/src/main/java/com/bitmovin/analytics/conviva/ConvivaAnalyticsIntegration.java
@@ -666,11 +666,14 @@ public class ConvivaAnalyticsIntegration {
 
         adInfo.put("c3.ad.technology", "Client Side");
         if (adStartedEvent.getClientType() == AdSourceType.Ima) {
+            String imaSdkVersion;
+            if (metadataOverrides != null && metadataOverrides.getImaSdkVersion() != null) {
+                imaSdkVersion = metadataOverrides.getImaSdkVersion();
+            } else {
+                imaSdkVersion = "NA";
+            }
             adInfo.put(ConvivaSdkConstants.FRAMEWORK_NAME, "Google IMA SDK");
-            adInfo.put(
-                    ConvivaSdkConstants.FRAMEWORK_VERSION,
-                    metadataOverrides.getImaSdkVersion() != null ? metadataOverrides.getImaSdkVersion() : "NA"
-            );
+            adInfo.put(ConvivaSdkConstants.FRAMEWORK_VERSION, imaSdkVersion);
         } else {
             adInfo.put(ConvivaSdkConstants.FRAMEWORK_NAME, "Bitmovin");
             adInfo.put(ConvivaSdkConstants.FRAMEWORK_VERSION, playerHelper.getSdkVersionString());


### PR DESCRIPTION
## Problem

When an IMA ad starts before `MetadataOverrides` are set the integration produces a `NullPointerException`.


## Changes
- In case of an IMA ad starting before `MetadataOverrides` are set report `NA` as ads framework version.

