### PR TITLE
Extract functionality to prepare for SSAI tracking

### DIFF
--- a/conviva/src/main/java/com/bitmovin/analytics/conviva/ConvivaAnalyticsIntegration.java
+++ b/conviva/src/main/java/com/bitmovin/analytics/conviva/ConvivaAnalyticsIntegration.java
@@ -472,9 +472,7 @@ public class ConvivaAnalyticsIntegration {
         @Override
         public void onEvent(PlayerEvent.Error event) {
             Log.d(TAG, "[Player Event] Error");
-            String message = String.format("%s - %s", event.getCode(), event.getMessage());
-            convivaVideoAnalytics.reportPlaybackError(message, ConvivaSdkConstants.ErrorSeverity.FATAL);
-            internalEndSession();
+            handleError(String.format("%s - %s", event.getCode(), event.getMessage()));
         }
     };
 
@@ -482,11 +480,15 @@ public class ConvivaAnalyticsIntegration {
         @Override
         public void onEvent(SourceEvent.Error event) {
             Log.d(TAG, "[Source Event] Error");
-            String message = String.format("%s - %s", event.getCode(), event.getMessage());
-            convivaVideoAnalytics.reportPlaybackError(message, ConvivaSdkConstants.ErrorSeverity.FATAL);
-            internalEndSession();
+            handleError(String.format("%s - %s", event.getCode(), event.getMessage()));
         }
     };
+
+    private void handleError(String message) {
+        ConvivaSdkConstants.ErrorSeverity severity = ConvivaSdkConstants.ErrorSeverity.FATAL;
+        convivaVideoAnalytics.reportPlaybackError(message, severity);
+        internalEndSession();
+    }
 
     private final EventListener<PlayerEvent.Warning> onPlayerWarningListener = new EventListener<PlayerEvent.Warning>() {
         @Override

--- a/conviva/src/main/java/com/bitmovin/analytics/conviva/ConvivaAnalyticsIntegration.java
+++ b/conviva/src/main/java/com/bitmovin/analytics/conviva/ConvivaAnalyticsIntegration.java
@@ -104,7 +104,7 @@ public class ConvivaAnalyticsIntegration {
         convivaAdAnalytics.setCallback(new ConvivaExperienceAnalytics.ICallback() {
             @Override
             public void update() {
-                if (bitmovinPlayer.isAd()) {
+                if (isAdActive()) {
                     convivaAdAnalytics.reportAdMetric(ConvivaSdkConstants.PLAYBACK.PLAY_HEAD_TIME, ((long) (bitmovinPlayer.getCurrentTime() * 1000)));
                 }
             }
@@ -113,6 +113,10 @@ public class ConvivaAnalyticsIntegration {
             public void update(String s) {
             }
         });
+    }
+
+    private boolean isAdActive() {
+        return bitmovinPlayer.isAd();
     }
 
     // region public methods
@@ -446,7 +450,7 @@ public class ConvivaAnalyticsIntegration {
     private synchronized void transitionState(ConvivaSdkConstants.PlayerState state) {
         Log.d(TAG, "Transitioning to :" + state.name());
         convivaVideoAnalytics.reportPlaybackMetric(ConvivaSdkConstants.PLAYBACK.PLAYER_STATE, state);
-        if (bitmovinPlayer.isAd()) {
+        if (isAdActive()) {
             Log.d(TAG, "Transitioning ad state to: " + state.name());
             convivaAdAnalytics.reportAdMetric(ConvivaSdkConstants.PLAYBACK.PLAYER_STATE, state);
         }


### PR DESCRIPTION
## Problem
In order to prepare the current integration for SSAI tracking, error tracking and ad status tracking needs to be extracted.


## Changes
- **Introduce private `isAdActive` function to improve extensability**
- **Extract common error handling functionality**

## Related Changes
- #69
- #70 
