### PR TITLE
Introduce SSAI API

### DIFF
--- a/conviva/src/main/java/com/bitmovin/analytics/conviva/ssai/AdPosition.java
+++ b/conviva/src/main/java/com/bitmovin/analytics/conviva/ssai/AdPosition.java
@@ -1,0 +1,7 @@
+package com.bitmovin.analytics.conviva.ssai;
+
+public enum AdPosition {
+    PREROLL,
+    MIDROLL,
+    POSTROLL;
+}

--- a/conviva/src/main/java/com/bitmovin/analytics/conviva/ssai/DefaultPlaybackStateProvider.java
+++ b/conviva/src/main/java/com/bitmovin/analytics/conviva/ssai/DefaultPlaybackStateProvider.java
@@ -1,0 +1,25 @@
+package com.bitmovin.analytics.conviva.ssai;
+
+import com.bitmovin.player.api.Player;
+import com.conviva.sdk.ConvivaSdkConstants;
+
+public class DefaultPlaybackStateProvider implements PlaybackStateProvider {
+    private final Player player;
+
+    public DefaultPlaybackStateProvider(Player player) {
+        this.player = player;
+    }
+
+    @Override
+    public ConvivaSdkConstants.PlayerState getPlayerState() {
+        ConvivaSdkConstants.PlayerState state;
+        if (player.isPaused()) {
+            state = ConvivaSdkConstants.PlayerState.PAUSED;
+        } else if (player.isStalled()) {
+            state = ConvivaSdkConstants.PlayerState.BUFFERING;
+        } else {
+            state = ConvivaSdkConstants.PlayerState.PLAYING;
+        }
+        return state;
+    }
+}

--- a/conviva/src/main/java/com/bitmovin/analytics/conviva/ssai/DefaultSsaiApi.java
+++ b/conviva/src/main/java/com/bitmovin/analytics/conviva/ssai/DefaultSsaiApi.java
@@ -1,0 +1,155 @@
+package com.bitmovin.analytics.conviva.ssai;
+
+import android.util.Log;
+
+import com.conviva.sdk.ConvivaAdAnalytics;
+import com.conviva.sdk.ConvivaSdkConstants;
+import com.conviva.sdk.ConvivaVideoAnalytics;
+
+import java.util.HashMap;
+import java.util.Map;
+
+
+public class DefaultSsaiApi implements SsaiApi {
+    private static final String TAG = "DefaultSsaiApi";
+    private final ConvivaVideoAnalytics convivaVideoAnalytics;
+    private final ConvivaAdAnalytics convivaAdAnalytics;
+    private final PlaybackStateProvider player;
+
+    public DefaultSsaiApi(ConvivaVideoAnalytics convivaVideoAnalytics, ConvivaAdAnalytics convivaAdAnalytics, PlaybackStateProvider player) {
+        this.convivaVideoAnalytics = convivaVideoAnalytics;
+        this.convivaAdAnalytics = convivaAdAnalytics;
+        this.player = player;
+    }
+
+    private boolean isAdBreakActive = false;
+
+    @Override
+    public boolean isAdBreakActive() {
+        return isAdBreakActive;
+    }
+
+    @Override
+    public void reportAdBreakStarted() {
+        reportAdBreakStarted(null);
+    }
+
+    public void reset() {
+        isAdBreakActive = false;
+    }
+
+    @Override
+    public void reportAdBreakStarted(Map<String, Object> adBreakInfo) {
+        if (isAdBreakActive) {
+            Log.d(TAG, "Server side ad break already active");
+            return;
+        }
+        isAdBreakActive = true;
+        Log.d(TAG, "Server side ad break started");
+        convivaVideoAnalytics.reportAdBreakStarted(ConvivaSdkConstants.AdPlayer.CONTENT, ConvivaSdkConstants.AdType.SERVER_SIDE, adBreakInfo);
+    }
+
+
+    @Override
+    public void reportAdBreakFinished() {
+        if (!isAdBreakActive) {
+            Log.d(TAG, "No server side ad break active");
+            return;
+        }
+        isAdBreakActive = false;
+        Log.d(TAG, "Server side ad break finished");
+        convivaVideoAnalytics.reportAdBreakEnded();
+    }
+
+
+    @Override
+    public void reportAdStarted(AdInfo adInfo) {
+        if (!isAdBreakActive) {
+            Log.d(TAG, "No server side ad break active");
+            return;
+        }
+        Log.d(TAG, "Server side ad started");
+        convivaAdAnalytics.reportAdStarted(convertToConvivaAdInfo(adInfo));
+        convivaAdAnalytics.reportAdMetric(ConvivaSdkConstants.PLAYBACK.PLAYER_STATE, player.getPlayerState());
+    }
+
+    @Override
+    public void reportAdFinished() {
+        if (!isAdBreakActive) {
+            Log.d(TAG, "No ad break active");
+            return;
+        }
+        Log.d(TAG, "Server side ad finished");
+        convivaAdAnalytics.reportAdEnded();
+    }
+
+    @Override
+    public void reportAdSkipped() {
+        if (!isAdBreakActive) {
+            Log.d(TAG, "No ad break active");
+            return;
+        }
+        isAdBreakActive = false;
+        Log.d(TAG, "Server side ad skipped");
+        convivaAdAnalytics.reportAdSkipped();
+    }
+
+    @Override
+    public void updateAdInfo(AdInfo adInfo) {
+        if (!isAdBreakActive) {
+            Log.d(TAG, "No ad break active");
+            return;
+        }
+        Log.d(TAG, "Setting ad info");
+
+        convivaAdAnalytics.setAdInfo(convertToConvivaAdInfo(adInfo));
+    }
+
+    private static Map<String, Object> convertToConvivaAdInfo(AdInfo adInfo) {
+        HashMap<String, Object> convivaAdInfo = new HashMap<>();
+        convivaAdInfo.put("c3.ad.id", "NA");
+        convivaAdInfo.put("c3.ad.system", "NA");
+        convivaAdInfo.put("c3.ad.mediaFileApiFramework", "NA");
+        convivaAdInfo.put("c3.ad.firstAdSystem", "NA");
+        convivaAdInfo.put("c3.ad.firstAdId", "NA");
+        convivaAdInfo.put("c3.ad.firstCreativeId", "NA");
+        convivaAdInfo.put("c3.ad.technology", "Server Side");
+
+        convivaAdInfo.put("c3.ad.isSlate", adInfo.isSlate());
+
+        if (adInfo.getTitle() != null) {
+            convivaAdInfo.put(ConvivaSdkConstants.ASSET_NAME, adInfo.getTitle());
+        }
+        if (adInfo.getDuration() != 0) {
+            convivaAdInfo.put(ConvivaSdkConstants.DURATION, adInfo.getDuration());
+        }
+        if (adInfo.getId() != null) {
+            convivaAdInfo.put("c3.ad.id", adInfo.getId());
+        }
+        if (adInfo.getAdSystem() != null) {
+            convivaAdInfo.put("c3.ad.system", adInfo.getAdSystem());
+        }
+        if (adInfo.getPosition() != null) {
+            convivaAdInfo.put("c3.ad.position", toConvivaAdPosition(adInfo.getPosition()));
+        }
+        if (adInfo.getAdStitcher() != null) {
+            convivaAdInfo.put("c3.ad.stitcher", adInfo.getAdStitcher());
+        }
+        if (adInfo.getAdditionalMetadata() != null) {
+            convivaAdInfo.putAll(adInfo.getAdditionalMetadata());
+        }
+
+        return convivaAdInfo;
+    }
+
+    private static ConvivaSdkConstants.AdPosition toConvivaAdPosition(AdPosition position) {
+        switch (position) {
+            case PREROLL:
+                return ConvivaSdkConstants.AdPosition.PREROLL;
+            case POSTROLL:
+                return ConvivaSdkConstants.AdPosition.POSTROLL;
+            default:
+                return ConvivaSdkConstants.AdPosition.MIDROLL;
+        }
+    }
+}

--- a/conviva/src/main/java/com/bitmovin/analytics/conviva/ssai/DefaultSsaiApi.java
+++ b/conviva/src/main/java/com/bitmovin/analytics/conviva/ssai/DefaultSsaiApi.java
@@ -89,7 +89,6 @@ public class DefaultSsaiApi implements SsaiApi {
             Log.d(TAG, "No ad break active");
             return;
         }
-        isAdBreakActive = false;
         Log.d(TAG, "Server side ad skipped");
         convivaAdAnalytics.reportAdSkipped();
     }

--- a/conviva/src/main/java/com/bitmovin/analytics/conviva/ssai/PlaybackStateProvider.java
+++ b/conviva/src/main/java/com/bitmovin/analytics/conviva/ssai/PlaybackStateProvider.java
@@ -1,0 +1,7 @@
+package com.bitmovin.analytics.conviva.ssai;
+
+import com.conviva.sdk.ConvivaSdkConstants;
+
+public interface PlaybackStateProvider {
+    ConvivaSdkConstants.PlayerState getPlayerState();
+}

--- a/conviva/src/main/java/com/bitmovin/analytics/conviva/ssai/SsaiApi.java
+++ b/conviva/src/main/java/com/bitmovin/analytics/conviva/ssai/SsaiApi.java
@@ -7,7 +7,7 @@ import java.util.Map;
  */
 public interface SsaiApi {
     /**
-     * Checks if a server-side ad break is currently active.
+     * Reports if a server-side ad break is currently active.
      *
      * @return <code>true</code> if a server-side ad break is active, <code>false</code> otherwise.
      */

--- a/conviva/src/main/java/com/bitmovin/analytics/conviva/ssai/SsaiApi.java
+++ b/conviva/src/main/java/com/bitmovin/analytics/conviva/ssai/SsaiApi.java
@@ -1,0 +1,168 @@
+package com.bitmovin.analytics.conviva.ssai;
+
+import java.util.Map;
+
+/**
+ * Enables reporting of server-side ad breaks and ads.
+ */
+public interface SsaiApi {
+    /**
+     * Checks if a server-side ad break is currently active.
+     *
+     * @return <code>true</code> if a server-side ad break is active, <code>false</code> otherwise.
+     */
+    boolean isAdBreakActive();
+
+    /**
+     * Reports the start of a server-side ad break. Must be called before the first ad starts.
+     * Has no effect if a server-side ad break is already playing.
+     */
+    void reportAdBreakStarted();
+
+    /**
+     * Reports the start of a server-side ad break. Must be called before the first ad starts.
+     * Has no effect if a server-side ad break is already playing.
+     *
+     * @param adBreakInfo Map containing metadata about the server-side ad break. Can be <code>null</code>.
+     */
+    void reportAdBreakStarted(Map<String, Object> adBreakInfo);
+
+    /**
+     * Reports the end of a server-side ad break. Must be called after the last ad has finished.
+     * Has no effect if no server-side ad break is currently active.
+     */
+    void reportAdBreakFinished();
+
+    /**
+     * Reports the start of a server-side ad.
+     *
+     * @param adInfo Object containing metadata about the server-side ad.
+     */
+    void reportAdStarted(AdInfo adInfo);
+
+    /**
+     * Reports the end of a server-side ad.
+     * Has no effect if no server-side ad is currently playing.
+     */
+    void reportAdFinished();
+
+    /**
+     * Reports that the current ad was skipped.
+     * Has no effect if no server-side ad is playing.
+     */
+    void reportAdSkipped();
+
+    /**
+     * Updates the ad metadata during an active client-side or server-side ad.
+     * Has no effect if no server-side ad is playing.
+     *
+     * @param adInfo Object containing metadata about the ad.
+     */
+    void updateAdInfo(AdInfo adInfo);
+
+    /**
+     * Represents metadata for an ad.
+     */
+    class AdInfo {
+        private String title;
+        private double duration;
+        private String id;
+        private String adSystem;
+        private AdPosition position;
+        private boolean isSlate = false;
+        private String adStitcher;
+        private Map<String, Object> additionalMetadata;
+
+        public double getDuration() {
+            return duration;
+        }
+
+        /**
+         * Duration of the ad, in seconds.
+         */
+        public void setDuration(double duration) {
+            this.duration = duration;
+        }
+
+        public String getId() {
+            return id;
+        }
+
+        /**
+         * The ad ID extracted from the ad server that contains the ad creative.
+         */
+        public void setId(String id) {
+            this.id = id;
+        }
+
+        public String getAdSystem() {
+            return adSystem;
+        }
+
+        /**
+         * The name of the ad system (i.e., the ad server).
+         */
+        public void setAdSystem(String adSystem) {
+            this.adSystem = adSystem;
+        }
+
+        public AdPosition getPosition() {
+            return position;
+        }
+
+        /**
+         * The position of the ad.
+         */
+        public void setPosition(AdPosition position) {
+            this.position = position;
+        }
+
+        public boolean isSlate() {
+            return isSlate;
+        }
+
+        /**
+         * Indicates whether this ad is a slate or not. Set to <code>true</code> for slate and <code>false</code> for a regular ad.
+         * Default is <code>false</code>.
+         */
+        public void setSlate(boolean slate) {
+            isSlate = slate;
+        }
+
+        public String getAdStitcher() {
+            return adStitcher;
+        }
+
+        /**
+         * The name of the ad stitcher.
+         */
+        public void setAdStitcher(String adStitcher) {
+            this.adStitcher = adStitcher;
+        }
+
+        public Map<String, Object> getAdditionalMetadata() {
+            return additionalMetadata;
+        }
+
+        /**
+         * Additional ad metadata. This is a map of key-value pairs that can be used to pass additional metadata about the ad.
+         * A list of ad metadata can be found here: <a href="https://pulse.conviva.com/learning-center/content/sensor_developer_center/sensor_integration/android/android_stream_sensor.htm#IntegrateAdManagers">Conviva documentation</a>
+         * <p>
+         * Metadata provided here will supersede any data provided in the ad break info.
+         */
+        public void setAdditionalMetadata(Map<String, Object> additionalMetadata) {
+            this.additionalMetadata = additionalMetadata;
+        }
+
+        public String getTitle() {
+            return title;
+        }
+
+        /**
+         * The title of the ad.
+         */
+        public void setTitle(String title) {
+            this.title = title;
+        }
+    }
+}

--- a/conviva/src/main/java/com/bitmovin/analytics/conviva/ssai/SsaiApi.java
+++ b/conviva/src/main/java/com/bitmovin/analytics/conviva/ssai/SsaiApi.java
@@ -35,6 +35,8 @@ public interface SsaiApi {
 
     /**
      * Reports the start of a server-side ad.
+     * <p>
+     * Has to be called after calling the <code>reportAdBreakStarted</code> method.
      *
      * @param adInfo Object containing metadata about the server-side ad.
      */

--- a/conviva/src/test/kotlin/com/bitmovin/analytics/conviva/ssai/DefaultSsaiApiTest.kt
+++ b/conviva/src/test/kotlin/com/bitmovin/analytics/conviva/ssai/DefaultSsaiApiTest.kt
@@ -11,8 +11,10 @@ import io.mockk.mockk
 import io.mockk.mockkStatic
 import io.mockk.runs
 import io.mockk.slot
+import io.mockk.unmockkStatic
 import io.mockk.verify
 import org.junit.After
+import org.junit.AfterClass
 import org.junit.Before
 import org.junit.BeforeClass
 import org.junit.Test
@@ -189,7 +191,7 @@ class DefaultSsaiApiTest {
         ssaiApi.reportAdSkipped()
 
         verify { adAnalytics.reportAdSkipped() }
-        expectThat(ssaiApi.isAdBreakActive).isFalse()
+        expectThat(ssaiApi.isAdBreakActive).isTrue()
     }
 
     @Test
@@ -244,6 +246,12 @@ class DefaultSsaiApiTest {
             every { Log.d(any(), any()) } returns 0
             every { Log.i(any(), any()) } returns 0
             every { Log.e(any(), any()) } returns 0
+        }
+
+        @JvmStatic
+        @AfterClass
+        fun afterClass() {
+            unmockkStatic(Log::class)
         }
     }
 }

--- a/conviva/src/test/kotlin/com/bitmovin/analytics/conviva/ssai/DefaultSsaiApiTest.kt
+++ b/conviva/src/test/kotlin/com/bitmovin/analytics/conviva/ssai/DefaultSsaiApiTest.kt
@@ -1,0 +1,249 @@
+package com.bitmovin.analytics.conviva.ssai
+
+import android.util.Log
+import com.conviva.sdk.ConvivaAdAnalytics
+import com.conviva.sdk.ConvivaSdkConstants
+import com.conviva.sdk.ConvivaVideoAnalytics
+import io.mockk.clearMocks
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.runs
+import io.mockk.slot
+import io.mockk.verify
+import org.junit.After
+import org.junit.Before
+import org.junit.BeforeClass
+import org.junit.Test
+import strikt.api.expectThat
+import strikt.assertions.contains
+import strikt.assertions.containsExactlyInAnyOrder
+import strikt.assertions.isEqualTo
+import strikt.assertions.isFalse
+import strikt.assertions.isTrue
+
+
+class DefaultSsaiApiTest {
+    private val videoAnalytics: ConvivaVideoAnalytics = mockk(relaxed = true)
+    private val adAnalytics: ConvivaAdAnalytics = mockk()
+    private val playbackStateProvider = mockk<PlaybackStateProvider>()
+    private val ssaiApi = DefaultSsaiApi(
+            videoAnalytics,
+            adAnalytics,
+            playbackStateProvider,
+    )
+
+    @Before
+    fun beforeTest() {
+        every { playbackStateProvider.playerState } returns ConvivaSdkConstants.PlayerState.PLAYING
+        with(adAnalytics) {
+            every { reportAdMetric(ConvivaSdkConstants.PLAYBACK.PLAYER_STATE, any()) } just runs
+            every { reportAdStarted(any()) } just runs
+            every { reportAdEnded() } just runs
+            every { reportAdSkipped() } just runs
+            every { setAdInfo(any()) } just runs
+        }
+    }
+
+    @After
+    fun afterTest() {
+        clearMocks(videoAnalytics, adAnalytics, playbackStateProvider)
+        ssaiApi.reset()
+    }
+
+
+    @Test
+    fun `reports server side ad break start to conviva after  ad break started`() {
+        ssaiApi.reportAdBreakStarted()
+        verify {
+            videoAnalytics.reportAdBreakStarted(
+                    ConvivaSdkConstants.AdPlayer.CONTENT,
+                    ConvivaSdkConstants.AdType.SERVER_SIDE,
+                    any(),
+            )
+        }
+    }
+
+    @Test
+    fun `has active ad break after ad break started`() {
+        ssaiApi.reportAdBreakStarted()
+        expectThat(ssaiApi.isAdBreakActive).isTrue()
+    }
+
+    @Test
+    fun `has no active ad break after ad break finished`() {
+        ssaiApi.reportAdBreakStarted()
+        expectThat(ssaiApi.isAdBreakActive).isTrue()
+
+        ssaiApi.reportAdBreakFinished()
+        expectThat(ssaiApi.isAdBreakActive).isFalse()
+    }
+
+    @Test
+    fun `reports ad start with default values to conviva when ad starts`() {
+        ssaiApi.reportAdBreakStarted()
+        ssaiApi.reportAdStarted(SsaiApi.AdInfo())
+
+        val slot = slot<MutableMap<String, Any>>()
+        verify {
+            adAnalytics.reportAdStarted(capture(slot))
+        }
+
+        expectThat(slot.captured.toList())
+                .containsExactlyInAnyOrder(
+                        listOf(
+                                "c3.ad.id" to "NA",
+                                "c3.ad.system" to "NA",
+                                "c3.ad.mediaFileApiFramework" to "NA",
+                                "c3.ad.firstAdSystem" to "NA",
+                                "c3.ad.firstAdId" to "NA",
+                                "c3.ad.firstCreativeId" to "NA",
+                                "c3.ad.technology" to "Server Side",
+                                "c3.ad.isSlate" to false,
+                        )
+                )
+    }
+
+    @Test
+    fun `reports ad playback state playing to conviva when ad starts`() {
+        ssaiApi.reportAdBreakStarted()
+        ssaiApi.reportAdStarted(SsaiApi.AdInfo())
+
+        verify {
+            adAnalytics.reportAdMetric(
+                    ConvivaSdkConstants.PLAYBACK.PLAYER_STATE,
+                    ConvivaSdkConstants.PlayerState.PLAYING,
+            )
+        }
+    }
+
+    @Test
+    fun `reports ad playback state playing to conviva when ad starts while paused`() {
+        every { playbackStateProvider.playerState } returns ConvivaSdkConstants.PlayerState.PAUSED
+
+        ssaiApi.reportAdBreakStarted()
+        ssaiApi.reportAdStarted(SsaiApi.AdInfo())
+
+        verify {
+            adAnalytics.reportAdMetric(
+                    ConvivaSdkConstants.PLAYBACK.PLAYER_STATE,
+                    ConvivaSdkConstants.PlayerState.PAUSED,
+            )
+        }
+    }
+
+    @Test
+    fun `reports ad playback state buffering to conviva when ad starts while stalling`() {
+        every { playbackStateProvider.playerState } returns
+                ConvivaSdkConstants.PlayerState.BUFFERING
+
+        ssaiApi.reportAdBreakStarted()
+        ssaiApi.reportAdStarted(SsaiApi.AdInfo())
+
+        verify {
+            adAnalytics.reportAdMetric(
+                    ConvivaSdkConstants.PLAYBACK.PLAYER_STATE,
+                    ConvivaSdkConstants.PlayerState.BUFFERING,
+            )
+        }
+    }
+
+    @Test
+    fun `reports ad start with overwritten metadata when ad starts with additional metadata`() {
+        ssaiApi.reportAdBreakStarted()
+        ssaiApi.reportAdStarted(SsaiApi.AdInfo().apply {
+            id = "adIdSetInFields"
+            additionalMetadata = mapOf("c3.ad.id" to "adIdSetInAdditionalMetadata")
+        })
+
+        val slot = slot<MutableMap<String, Any>>()
+        verify {
+            adAnalytics.reportAdStarted(capture(slot))
+        }
+
+        expectThat(slot.captured["c3.ad.id"]).isEqualTo("adIdSetInAdditionalMetadata")
+    }
+
+    @Test
+    fun `reports ad end to conviva when ad finished`() {
+        ssaiApi.reportAdBreakStarted()
+        ssaiApi.reportAdStarted(SsaiApi.AdInfo())
+        ssaiApi.reportAdFinished()
+
+        verify { adAnalytics.reportAdEnded() }
+    }
+
+    @Test
+    fun `reports ad break end to conviva when ad break finished`() {
+        ssaiApi.reportAdBreakStarted()
+        ssaiApi.reportAdBreakFinished()
+
+        verify { videoAnalytics.reportAdBreakEnded() }
+    }
+
+    @Test
+    fun `reports ad skipped to conviva when ad skipped`() {
+        ssaiApi.reportAdBreakStarted()
+        ssaiApi.reportAdStarted(SsaiApi.AdInfo())
+        ssaiApi.reportAdSkipped()
+
+        verify { adAnalytics.reportAdSkipped() }
+        expectThat(ssaiApi.isAdBreakActive).isFalse()
+    }
+
+    @Test
+    fun `reports ad metadata to conviva when updating ad info`() {
+        ssaiApi.reportAdBreakStarted()
+
+        val testAdInfo = SsaiApi.AdInfo().apply {
+            id = "adId"
+            adSystem = "adSystem"
+            title = "title"
+            position = AdPosition.PREROLL
+            adStitcher = "adStitcher"
+            duration = 1000.0
+            isSlate = true
+            additionalMetadata = mapOf("key" to "value")
+        }
+
+        ssaiApi.updateAdInfo(testAdInfo)
+
+        val slot = slot<MutableMap<String, Any>>()
+        verify { adAnalytics.setAdInfo(capture(slot)) }
+
+        expectThat(slot.captured.toList())
+                .contains(
+                        listOf(
+                                "c3.ad.id" to "adId",
+                                "c3.ad.system" to "adSystem",
+                                ConvivaSdkConstants.ASSET_NAME to "title",
+                                "c3.ad.position" to ConvivaSdkConstants.AdPosition.PREROLL,
+                                "c3.ad.stitcher" to "adStitcher",
+                                ConvivaSdkConstants.DURATION to 1000.0,
+                                "c3.ad.isSlate" to true,
+                                "key" to "value",
+                        )
+                )
+    }
+
+    @Test
+    fun `sets the ad break state to false when resetting`() {
+        ssaiApi.reportAdBreakStarted()
+        ssaiApi.reset()
+
+        expectThat(ssaiApi.isAdBreakActive).isFalse()
+    }
+
+    companion object {
+        @JvmStatic
+        @BeforeClass
+        fun beforeClass() {
+            mockkStatic(Log::class)
+            every { Log.v(any(), any()) } returns 0
+            every { Log.d(any(), any()) } returns 0
+            every { Log.i(any(), any()) } returns 0
+            every { Log.e(any(), any()) } returns 0
+        }
+    }
+}


### PR DESCRIPTION
## Problem
SSAI ad tracking is not yet supported

## Changes
- **Introduce new SSAI API without using it**
- **Add unit tests for SSAI API**

The following files are public API:
- [conviva/src/main/java/com/bitmovin/analytics/conviva/ssai/AdPosition.java](https://github.com/bitmovin/bitmovin-player-android-analytics-conviva/pull/72/files#diff-2b72a24c15b769f4ad13aaf8c38dfd17b334bc5ab062f3bc59bf9329e028a8ac)
- [conviva/src/main/java/com/bitmovin/analytics/conviva/ssai/SsaiApi.java](https://github.com/bitmovin/bitmovin-player-android-analytics-conviva/pull/72/files#diff-09f0b789cdf2f6d9ba79f472acc710306be834ef2d20d0c290153cef995ab8a6)

## Related Changes
- #69 
- #70 