### PR TITLE
Wire up SSAI

### DIFF
--- a/ConvivaTestApp/src/androidTest/java/com/bitmovin/analytics/conviva/testapp/SsaiTests.kt
+++ b/ConvivaTestApp/src/androidTest/java/com/bitmovin/analytics/conviva/testapp/SsaiTests.kt
@@ -1,0 +1,118 @@
+package com.bitmovin.analytics.conviva.testapp
+
+import android.os.Handler
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.bitmovin.analytics.conviva.ConvivaAnalyticsIntegration
+import com.bitmovin.analytics.conviva.ConvivaConfig
+import com.bitmovin.analytics.conviva.MetadataOverrides
+import com.bitmovin.analytics.conviva.ssai.SsaiApi
+import com.bitmovin.analytics.conviva.testapp.framework.BITMOVIN_PLAYER_LICENSE_KEY
+import com.bitmovin.analytics.conviva.testapp.framework.CONVIVA_CUSTOMER_KEY
+import com.bitmovin.analytics.conviva.testapp.framework.CONVIVA_GATEWAY_URL
+import com.bitmovin.analytics.conviva.testapp.framework.Sources
+import com.bitmovin.analytics.conviva.testapp.framework.expectEvent
+import com.bitmovin.analytics.conviva.testapp.framework.postWaiting
+import com.bitmovin.player.api.PlaybackConfig
+import com.bitmovin.player.api.Player
+import com.bitmovin.player.api.PlayerConfig
+import com.bitmovin.player.api.analytics.AnalyticsPlayerConfig
+import com.bitmovin.player.api.event.PlayerEvent
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import org.junit.Test
+import org.junit.runner.RunWith
+
+
+/**
+ * This test class does not verify any specific behavior, but rather can be used to validate the
+ * integration against the [Conviva Touchstone integration test tool](https://touchstone.conviva.com/).
+ */
+@RunWith(AndroidJUnit4::class)
+class SsaiTests {
+    /**
+     * Plays a vod stream and fakes a SSAI ad break with a single 5 seconds ad and a  1 seconds slate.
+     */
+    @Test
+    fun reports_ad_analytics_for_mid_roll_ad() {
+        val adStart = 5.0
+        val adDuration = 5.0
+        val slateStart = adStart + adDuration
+        val slateDuration = 1.0
+
+
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        val mainHandler = Handler(context.mainLooper)
+        val player = mainHandler.postWaiting {
+            Player(
+                    context,
+                    PlayerConfig(
+                            key = BITMOVIN_PLAYER_LICENSE_KEY,
+                            playbackConfig = PlaybackConfig(
+                                    isAutoplayEnabled = true,
+                            ),
+                    ),
+                    analyticsConfig = AnalyticsPlayerConfig.Disabled,
+            )
+        }
+
+        val integration = mainHandler.postWaiting {
+            val convivaAnalyticsIntegration = ConvivaAnalyticsIntegration(
+                    player,
+                    CONVIVA_CUSTOMER_KEY,
+                    context,
+                    ConvivaConfig().apply {
+                        isDebugLoggingEnabled = true
+                        gatewayUrl = CONVIVA_GATEWAY_URL
+                    },
+            )
+
+            convivaAnalyticsIntegration.updateContentMetadata(
+                    MetadataOverrides()
+                            .apply {
+                                applicationName = "Bitmovin Android Conviva integration example app"
+                                viewerId = "testViewerId"
+                            }
+            )
+            convivaAnalyticsIntegration
+        }
+
+        mainHandler.postWaiting { player.load(Sources.Dash.basic) }
+        player.expectEvent<PlayerEvent.TimeChanged> { it.time > adStart } // play main content until ad start
+
+        // fake ad break
+        mainHandler.postWaiting {
+            integration.ssai.reportAdBreakStarted()
+            integration.ssai.reportAdStarted(SsaiApi.AdInfo().apply {
+                duration = adDuration
+                isSlate = false
+                id = "testAdId"
+                title = "testAdTitle"
+            })
+        }
+
+        player.expectEvent<PlayerEvent.TimeChanged> { it.time > adStart + adDuration } // wait unitl ad is over
+
+
+        mainHandler.postWaiting {
+            integration.ssai.reportAdFinished()
+            integration.ssai.reportAdStarted(
+                    SsaiApi.AdInfo().apply {
+                        duration = slateDuration
+                        isSlate = true
+                        title = "testSlate"
+                    }
+            )
+        }
+
+        player.expectEvent<PlayerEvent.TimeChanged> { it.time > slateStart + slateDuration } // wait for five more seconds of playback
+
+        mainHandler.postWaiting {
+            integration.ssai.reportAdFinished()
+            integration.ssai.reportAdBreakFinished()
+        }
+
+        mainHandler.postWaiting { player.destroy() }
+        runBlocking { delay(1000) }
+    }
+}

--- a/conviva/src/main/java/com/bitmovin/analytics/conviva/ConvivaAnalyticsIntegration.java
+++ b/conviva/src/main/java/com/bitmovin/analytics/conviva/ConvivaAnalyticsIntegration.java
@@ -4,6 +4,9 @@ import android.content.Context;
 import android.os.Handler;
 import android.util.Log;
 
+import com.bitmovin.analytics.conviva.ssai.DefaultPlaybackStateProvider;
+import com.bitmovin.analytics.conviva.ssai.DefaultSsaiApi;
+import com.bitmovin.analytics.conviva.ssai.SsaiApi;
 import com.bitmovin.player.api.Player;
 import com.bitmovin.player.api.advertising.Ad;
 import com.bitmovin.player.api.advertising.AdData;
@@ -36,6 +39,8 @@ public class ConvivaAnalyticsIntegration {
     private final ConvivaVideoAnalytics convivaVideoAnalytics;
     private final ConvivaAdAnalytics convivaAdAnalytics;
     private MetadataOverrides metadataOverrides;
+    private final DefaultSsaiApi ssai;
+
 
     // Wrapper to extract bitmovinPlayer helper methods
     private final BitmovinPlayerHelper playerHelper;
@@ -72,6 +77,20 @@ public class ConvivaAnalyticsIntegration {
                                        ConvivaVideoAnalytics videoAnalytics,
                                        ConvivaAdAnalytics adAnalytics
     ) {
+        this(player, customerKey, context, config, videoAnalytics, adAnalytics, null);
+    }
+
+    /**
+     * For testing purposes only.
+     */
+    ConvivaAnalyticsIntegration(Player player,
+                                String customerKey,
+                                Context context,
+                                ConvivaConfig config,
+                                ConvivaVideoAnalytics videoAnalytics,
+                                ConvivaAdAnalytics adAnalytics,
+                                DefaultSsaiApi ssai
+    ) {
         this.bitmovinPlayer = player;
         this.playerHelper = new BitmovinPlayerHelper(player);
         Map<String, Object> settings = new HashMap<>();
@@ -94,6 +113,12 @@ public class ConvivaAnalyticsIntegration {
             convivaAdAnalytics = ConvivaAnalytics.buildAdAnalytics(context, convivaVideoAnalytics);
         } else {
             convivaAdAnalytics = adAnalytics;
+        }
+
+        if (ssai == null) {
+            this.ssai = new DefaultSsaiApi(convivaVideoAnalytics, convivaAdAnalytics, new DefaultPlaybackStateProvider(player));
+        } else {
+            this.ssai = ssai;
         }
 
         attachBitmovinEventListeners();

--- a/conviva/src/main/java/com/bitmovin/analytics/conviva/ConvivaAnalyticsIntegration.java
+++ b/conviva/src/main/java/com/bitmovin/analytics/conviva/ConvivaAnalyticsIntegration.java
@@ -516,6 +516,9 @@ public class ConvivaAnalyticsIntegration {
 
     private void handleError(String message) {
         ConvivaSdkConstants.ErrorSeverity severity = ConvivaSdkConstants.ErrorSeverity.FATAL;
+        if (ssai.isAdBreakActive()) {
+            convivaAdAnalytics.reportAdError(message, severity);
+        }
         convivaVideoAnalytics.reportPlaybackError(message, severity);
         internalEndSession();
     }

--- a/conviva/src/main/java/com/bitmovin/analytics/conviva/ConvivaAnalyticsIntegration.java
+++ b/conviva/src/main/java/com/bitmovin/analytics/conviva/ConvivaAnalyticsIntegration.java
@@ -141,7 +141,7 @@ public class ConvivaAnalyticsIntegration {
     }
 
     private boolean isAdActive() {
-        return bitmovinPlayer.isAd();
+        return bitmovinPlayer.isAd() || ssai.isAdBreakActive();
     }
 
     // region public methods
@@ -389,6 +389,7 @@ public class ConvivaAnalyticsIntegration {
     }
 
     private void internalEndSession() {
+        ssai.reset();
         contentMetadataBuilder.reset();
         if (!isSessionActive) {
             return;

--- a/conviva/src/main/java/com/bitmovin/analytics/conviva/ConvivaAnalyticsIntegration.java
+++ b/conviva/src/main/java/com/bitmovin/analytics/conviva/ConvivaAnalyticsIntegration.java
@@ -145,6 +145,10 @@ public class ConvivaAnalyticsIntegration {
     }
 
     // region public methods
+    public SsaiApi getSsai() {
+        return ssai;
+    }
+
     public void sendCustomApplicationEvent(String name) {
         sendCustomApplicationEvent(name, new HashMap<>());
     }

--- a/conviva/src/main/java/com/bitmovin/analytics/conviva/ssai/DefaultSsaiApi.java
+++ b/conviva/src/main/java/com/bitmovin/analytics/conviva/ssai/DefaultSsaiApi.java
@@ -35,7 +35,8 @@ public class DefaultSsaiApi implements SsaiApi {
     }
 
     public void reset() {
-        isAdBreakActive = false;
+        reportAdFinished();
+        reportAdBreakFinished();
     }
 
     @Override

--- a/conviva/src/test/kotlin/com/bitmovin/analytics/conviva/ssai/DefaultSsaiApiTest.kt
+++ b/conviva/src/test/kotlin/com/bitmovin/analytics/conviva/ssai/DefaultSsaiApiTest.kt
@@ -51,7 +51,6 @@ class DefaultSsaiApiTest {
     @After
     fun afterTest() {
         clearMocks(videoAnalytics, adAnalytics, playbackStateProvider)
-        ssaiApi.reset()
     }
 
 
@@ -230,10 +229,14 @@ class DefaultSsaiApiTest {
     }
 
     @Test
-    fun `sets the ad break state to false when resetting`() {
+    fun `ends potential ads and ad breaks when resetting`() {
         ssaiApi.reportAdBreakStarted()
+        ssaiApi.reportAdStarted(SsaiApi.AdInfo())
+
         ssaiApi.reset()
 
+        verify { adAnalytics.reportAdEnded() }
+        verify { videoAnalytics.reportAdBreakEnded() }
         expectThat(ssaiApi.isAdBreakActive).isFalse()
     }
 


### PR DESCRIPTION
## Problem 
The SSAI API introduced in #72 is not yet used.

## Changes
- **Add SSAI API to ConvivaAnalyticsIntegration**
- **Expose SSAI namespace on ConvivaAnalyticsIntegration**
- **Reset SSAI state on internal session end**
- **Report stream error as ad error in case of active SSAI ad**
- **Add first instrumentation test**

## Limitations

On SSAI ad start we currently don't report initial values for resolution, bitrate and framerate. This will be done in a follow up PR.


## Related Changes
#69 
#72 