### PR TITLE
Report video playback data for SSAI ads

### DIFF
--- a/conviva/src/main/java/com/bitmovin/analytics/conviva/ConvivaAnalyticsIntegration.java
+++ b/conviva/src/main/java/com/bitmovin/analytics/conviva/ConvivaAnalyticsIntegration.java
@@ -345,15 +345,21 @@ public class ConvivaAnalyticsIntegration {
     }
 
     private void updateSession() {
-        this.buildDynamicContentMetadata();
-
-        HashMap<String, Object[]> playbackVideoData = playbackInfoProvider.getPlaybackVideoData();
-        for (Map.Entry<String, Object[]> entry : playbackVideoData.entrySet()) {
-            convivaVideoAnalytics.reportPlaybackMetric(entry.getKey(), entry.getValue());
-        }
+        updatePlaybackVideoData();
+        buildDynamicContentMetadata();
 
         if (isSessionActive) {
             convivaVideoAnalytics.setContentInfo(contentMetadataBuilder.build());
+        }
+    }
+
+    private void updatePlaybackVideoData() {
+        HashMap<String, Object[]> playbackVideoData = playbackInfoProvider.getPlaybackVideoData();
+        for (Map.Entry<String, Object[]> entry : playbackVideoData.entrySet()) {
+            convivaVideoAnalytics.reportPlaybackMetric(entry.getKey(), entry.getValue());
+            if (ssai.isAdBreakActive()) {
+                convivaAdAnalytics.reportAdMetric(entry.getKey(), entry.getValue());
+            }
         }
     }
 

--- a/conviva/src/main/java/com/bitmovin/analytics/conviva/ssai/DefaultPlaybackInfoProvider.java
+++ b/conviva/src/main/java/com/bitmovin/analytics/conviva/ssai/DefaultPlaybackInfoProvider.java
@@ -4,6 +4,8 @@ import com.bitmovin.player.api.Player;
 import com.bitmovin.player.api.media.video.quality.VideoQuality;
 import com.conviva.sdk.ConvivaSdkConstants;
 
+import java.util.HashMap;
+
 public class DefaultPlaybackInfoProvider implements PlaybackInfoProvider {
     private final Player player;
 
@@ -25,7 +27,14 @@ public class DefaultPlaybackInfoProvider implements PlaybackInfoProvider {
     }
 
     @Override
-    public VideoQuality getPlaybackVideoData() {
-        return player.getPlaybackVideoData();
+    public HashMap<String, Object[]> getPlaybackVideoData() {
+        HashMap<String, Object[]> videoData = new HashMap<>();
+        VideoQuality playbackVideoData = player.getPlaybackVideoData();
+        if (playbackVideoData != null) {
+            videoData.put(ConvivaSdkConstants.PLAYBACK.RESOLUTION, new Object[]{playbackVideoData.getWidth(), playbackVideoData.getHeight()});
+            videoData.put(ConvivaSdkConstants.PLAYBACK.BITRATE, new Object[]{playbackVideoData.getBitrate() / 1000});
+            videoData.put(ConvivaSdkConstants.PLAYBACK.RENDERED_FRAMERATE, new Object[]{Math.round(playbackVideoData.getFrameRate())});
+        }
+        return videoData;
     }
 }

--- a/conviva/src/main/java/com/bitmovin/analytics/conviva/ssai/DefaultPlaybackInfoProvider.java
+++ b/conviva/src/main/java/com/bitmovin/analytics/conviva/ssai/DefaultPlaybackInfoProvider.java
@@ -1,12 +1,13 @@
 package com.bitmovin.analytics.conviva.ssai;
 
 import com.bitmovin.player.api.Player;
+import com.bitmovin.player.api.media.video.quality.VideoQuality;
 import com.conviva.sdk.ConvivaSdkConstants;
 
-public class DefaultPlaybackStateProvider implements PlaybackStateProvider {
+public class DefaultPlaybackInfoProvider implements PlaybackInfoProvider {
     private final Player player;
 
-    public DefaultPlaybackStateProvider(Player player) {
+    public DefaultPlaybackInfoProvider(Player player) {
         this.player = player;
     }
 
@@ -21,5 +22,10 @@ public class DefaultPlaybackStateProvider implements PlaybackStateProvider {
             state = ConvivaSdkConstants.PlayerState.PLAYING;
         }
         return state;
+    }
+
+    @Override
+    public VideoQuality getPlaybackVideoData() {
+        return player.getPlaybackVideoData();
     }
 }

--- a/conviva/src/main/java/com/bitmovin/analytics/conviva/ssai/DefaultSsaiApi.java
+++ b/conviva/src/main/java/com/bitmovin/analytics/conviva/ssai/DefaultSsaiApi.java
@@ -2,6 +2,7 @@ package com.bitmovin.analytics.conviva.ssai;
 
 import android.util.Log;
 
+import com.bitmovin.player.api.media.video.quality.VideoQuality;
 import com.conviva.sdk.ConvivaAdAnalytics;
 import com.conviva.sdk.ConvivaSdkConstants;
 import com.conviva.sdk.ConvivaVideoAnalytics;
@@ -14,9 +15,9 @@ public class DefaultSsaiApi implements SsaiApi {
     private static final String TAG = "DefaultSsaiApi";
     private final ConvivaVideoAnalytics convivaVideoAnalytics;
     private final ConvivaAdAnalytics convivaAdAnalytics;
-    private final PlaybackStateProvider player;
+    private final PlaybackInfoProvider player;
 
-    public DefaultSsaiApi(ConvivaVideoAnalytics convivaVideoAnalytics, ConvivaAdAnalytics convivaAdAnalytics, PlaybackStateProvider player) {
+    public DefaultSsaiApi(ConvivaVideoAnalytics convivaVideoAnalytics, ConvivaAdAnalytics convivaAdAnalytics, PlaybackInfoProvider player) {
         this.convivaVideoAnalytics = convivaVideoAnalytics;
         this.convivaAdAnalytics = convivaAdAnalytics;
         this.player = player;
@@ -70,7 +71,17 @@ public class DefaultSsaiApi implements SsaiApi {
         }
         Log.d(TAG, "Server side ad started");
         convivaAdAnalytics.reportAdStarted(convertToConvivaAdInfo(adInfo));
+        reportInitialAdMetrics();
+    }
+
+    private void reportInitialAdMetrics() {
         convivaAdAnalytics.reportAdMetric(ConvivaSdkConstants.PLAYBACK.PLAYER_STATE, player.getPlayerState());
+        VideoQuality videoQuality = player.getPlaybackVideoData();
+        if (videoQuality != null) {
+            convivaAdAnalytics.reportAdMetric(ConvivaSdkConstants.PLAYBACK.RESOLUTION, videoQuality.getHeight(), videoQuality.getWidth());
+            convivaAdAnalytics.reportAdMetric(ConvivaSdkConstants.PLAYBACK.BITRATE, videoQuality.getBitrate() / 1000);
+            convivaAdAnalytics.reportAdMetric(ConvivaSdkConstants.PLAYBACK.RENDERED_FRAMERATE, Math.round(videoQuality.getFrameRate()));
+        }
     }
 
     @Override

--- a/conviva/src/main/java/com/bitmovin/analytics/conviva/ssai/DefaultSsaiApi.java
+++ b/conviva/src/main/java/com/bitmovin/analytics/conviva/ssai/DefaultSsaiApi.java
@@ -2,7 +2,6 @@ package com.bitmovin.analytics.conviva.ssai;
 
 import android.util.Log;
 
-import com.bitmovin.player.api.media.video.quality.VideoQuality;
 import com.conviva.sdk.ConvivaAdAnalytics;
 import com.conviva.sdk.ConvivaSdkConstants;
 import com.conviva.sdk.ConvivaVideoAnalytics;
@@ -77,11 +76,9 @@ public class DefaultSsaiApi implements SsaiApi {
 
     private void reportInitialAdMetrics() {
         convivaAdAnalytics.reportAdMetric(ConvivaSdkConstants.PLAYBACK.PLAYER_STATE, player.getPlayerState());
-        VideoQuality videoQuality = player.getPlaybackVideoData();
-        if (videoQuality != null) {
-            convivaAdAnalytics.reportAdMetric(ConvivaSdkConstants.PLAYBACK.RESOLUTION, videoQuality.getHeight(), videoQuality.getWidth());
-            convivaAdAnalytics.reportAdMetric(ConvivaSdkConstants.PLAYBACK.BITRATE, videoQuality.getBitrate() / 1000);
-            convivaAdAnalytics.reportAdMetric(ConvivaSdkConstants.PLAYBACK.RENDERED_FRAMERATE, Math.round(videoQuality.getFrameRate()));
+        HashMap<String, Object[]> playbackVideoData = player.getPlaybackVideoData();
+        for (Map.Entry<String, Object[]> entry : playbackVideoData.entrySet()) {
+            convivaAdAnalytics.reportAdMetric(entry.getKey(), entry.getValue());
         }
     }
 

--- a/conviva/src/main/java/com/bitmovin/analytics/conviva/ssai/PlaybackInfoProvider.java
+++ b/conviva/src/main/java/com/bitmovin/analytics/conviva/ssai/PlaybackInfoProvider.java
@@ -1,9 +1,11 @@
 package com.bitmovin.analytics.conviva.ssai;
 
-import com.bitmovin.player.api.media.video.quality.VideoQuality;
 import com.conviva.sdk.ConvivaSdkConstants;
+
+import java.util.HashMap;
 
 public interface PlaybackInfoProvider {
     ConvivaSdkConstants.PlayerState getPlayerState();
-    VideoQuality getPlaybackVideoData();
+
+    HashMap<String, Object[]> getPlaybackVideoData();
 }

--- a/conviva/src/main/java/com/bitmovin/analytics/conviva/ssai/PlaybackInfoProvider.java
+++ b/conviva/src/main/java/com/bitmovin/analytics/conviva/ssai/PlaybackInfoProvider.java
@@ -1,7 +1,9 @@
 package com.bitmovin.analytics.conviva.ssai;
 
+import com.bitmovin.player.api.media.video.quality.VideoQuality;
 import com.conviva.sdk.ConvivaSdkConstants;
 
-public interface PlaybackStateProvider {
+public interface PlaybackInfoProvider {
     ConvivaSdkConstants.PlayerState getPlayerState();
+    VideoQuality getPlaybackVideoData();
 }

--- a/conviva/src/test/kotlin/com/bitmovin/analytics/conviva/ssai/DefaultSsaiApiTest.kt
+++ b/conviva/src/test/kotlin/com/bitmovin/analytics/conviva/ssai/DefaultSsaiApiTest.kt
@@ -1,7 +1,6 @@
 package com.bitmovin.analytics.conviva.ssai
 
 import android.util.Log
-import com.bitmovin.player.api.media.video.quality.VideoQuality
 import com.conviva.sdk.ConvivaAdAnalytics
 import com.conviva.sdk.ConvivaSdkConstants
 import com.conviva.sdk.ConvivaVideoAnalytics
@@ -36,14 +35,10 @@ class DefaultSsaiApiTest {
     @Before
     fun beforeTest() {
         every { playbackInfoProvider.playerState } returns ConvivaSdkConstants.PlayerState.PLAYING
-        every { playbackInfoProvider.playbackVideoData } returns VideoQuality(
-                "videoQualityId",
-                "videoQualityLabel",
-                1000,
-                "codec",
-                60.1F,
-                1600,
-                800,
+        every { playbackInfoProvider.playbackVideoData } returns hashMapOf<String, Array<Any>>(
+                ConvivaSdkConstants.PLAYBACK.BITRATE to arrayOf(1),
+                ConvivaSdkConstants.PLAYBACK.RESOLUTION to arrayOf(800, 1600),
+                ConvivaSdkConstants.PLAYBACK.RENDERED_FRAMERATE to arrayOf(60),
         )
         with(adAnalytics) {
             every { reportAdMetric(ConvivaSdkConstants.PLAYBACK.PLAYER_STATE, any()) } just runs


### PR DESCRIPTION
## Problem
Initial ad metrics are not yet reported for SSAI ads

## Changes
- Report initial video playback metrics for server side ads
- Report ongoing video playback metrics for ssai
- Rename `PlaybackStateProvider` to `PlaybackInfoProvider` and add `getPlaybackVideoData` functionality

## Related Changes
- #70 
- #72 
- #73 
- #74 
- #75
- #76 