### PR TITLE
Copy metadata for SSAI from main content

### DIFF
--- a/conviva/src/main/java/com/bitmovin/analytics/conviva/ConvivaAnalyticsIntegration.java
+++ b/conviva/src/main/java/com/bitmovin/analytics/conviva/ConvivaAnalyticsIntegration.java
@@ -31,6 +31,8 @@ import java.util.List;
 import java.util.Map;
 
 public class ConvivaAnalyticsIntegration {
+    public static final String STREAM_TYPE = "streamType";
+    public static final String INTEGRATION_VERSION = "integrationVersion";
 
     private static final String TAG = "ConvivaAnalyticsInt";
 
@@ -374,8 +376,8 @@ public class ConvivaAnalyticsIntegration {
         // streamType could be missing at time of session initialization
         // as source information could be unavailable at that time
         Map<String, String> customInternTags = new HashMap<>();
-        customInternTags.put("streamType", playerHelper.getStreamType());
-        customInternTags.put("integrationVersion", BuildConfig.VERSION_NAME);
+        customInternTags.put(STREAM_TYPE, playerHelper.getStreamType());
+        customInternTags.put(INTEGRATION_VERSION, BuildConfig.VERSION_NAME);
         contentMetadataBuilder.setCustom(customInternTags);
 
         if (bitmovinPlayer.isLive()) {

--- a/conviva/src/main/java/com/bitmovin/analytics/conviva/ssai/DefaultSsaiApi.java
+++ b/conviva/src/main/java/com/bitmovin/analytics/conviva/ssai/DefaultSsaiApi.java
@@ -2,6 +2,7 @@ package com.bitmovin.analytics.conviva.ssai;
 
 import android.util.Log;
 
+import com.bitmovin.analytics.conviva.ConvivaAnalyticsIntegration;
 import com.conviva.sdk.ConvivaAdAnalytics;
 import com.conviva.sdk.ConvivaSdkConstants;
 import com.conviva.sdk.ConvivaVideoAnalytics;
@@ -138,8 +139,8 @@ public class DefaultSsaiApi implements SsaiApi {
         maybeCopyFromMainContent(mainContentMetadata, convivaAdInfo, ConvivaSdkConstants.IS_LIVE);
         maybeCopyFromMainContent(mainContentMetadata, convivaAdInfo, ConvivaSdkConstants.DEFAULT_RESOURCE);
         maybeCopyFromMainContent(mainContentMetadata, convivaAdInfo, ConvivaSdkConstants.ENCODED_FRAMERATE);
-        maybeCopyFromMainContent(mainContentMetadata, convivaAdInfo, "streamType");
-        maybeCopyFromMainContent(mainContentMetadata, convivaAdInfo, "integrationVersion");
+        maybeCopyFromMainContent(mainContentMetadata, convivaAdInfo, ConvivaAnalyticsIntegration.STREAM_TYPE);
+        maybeCopyFromMainContent(mainContentMetadata, convivaAdInfo, ConvivaAnalyticsIntegration.INTEGRATION_VERSION);
     }
 
     private static void maybeCopyFromMainContent(Map<String, Object> mainContentMetadata, HashMap<String, Object> convivaAdInfo, String key) {

--- a/conviva/src/test/kotlin/com/bitmovin/analytics/conviva/ssai/DefaultSsaiApiTest.kt
+++ b/conviva/src/test/kotlin/com/bitmovin/analytics/conviva/ssai/DefaultSsaiApiTest.kt
@@ -167,6 +167,29 @@ class DefaultSsaiApiTest {
     }
 
     @Test
+    fun `reports ad start with main content metadata when ad starts without overwriting it`() {
+        every { videoAnalytics.metadataInfo } returns mapOf(
+                "streamType" to "mainContentStreamType",
+                ConvivaSdkConstants.ASSET_NAME to "mainContentTitle",
+        )
+
+        ssaiApi.reportAdBreakStarted()
+        ssaiApi.reportAdStarted(SsaiApi.AdInfo().apply {
+            title = "overwrittenTitle"
+        })
+
+        val slot = slot<MutableMap<String, Any>>()
+        verify {
+            adAnalytics.reportAdStarted(capture(slot))
+        }
+
+        expectThat(slot){
+            get { captured[ConvivaSdkConstants.ASSET_NAME] }.isEqualTo("overwrittenTitle")
+            get { captured["streamType"] }.isEqualTo("mainContentStreamType")
+        }
+    }
+
+    @Test
     fun `reports ad end to conviva when ad finished`() {
         ssaiApi.reportAdBreakStarted()
         ssaiApi.reportAdStarted(SsaiApi.AdInfo())


### PR DESCRIPTION
## Problem
Some of the main content metadata has to be provided with the ad start:

- `ConvivaSdkConstants.STREAM_URL`
- `ConvivaSdkConstants.ASSET_NAME`
- `ConvivaSdkConstants.IS_LIVE`
- `ConvivaSdkConstants.DEFAULT_RESOURCE`
- `ConvivaSdkConstants.ENCODED_FRAMERATE`
- `"streamType"`
- `"integrationVersion"`

## Changes 
Copy over the values from the main content to the ad info if they are not overwritten there.

## Related Changes
- #70 
- #72 
- #73 
- #74 
- #75
- #76 
