### PR TITLE
Add support for average bitrate metric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 - Updated Bitmovin Player to `3.78.2`
 
-
 ## 2.5.0 - 2024-07-05
 ### Added
 - `ConvivaAnalyticsIntegration.ssai` namespace to enable server side ad tracking

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+
+## 2.6.0 - 2024-08-13
+### Added
+- `averageBitrate` to reported video metrics
+
+### Changed
+- Updated Bitmovin Player to `3.78.2`
+
+
 ## 2.5.0 - 2024-07-05
 ### Added
 - `ConvivaAnalyticsIntegration.ssai` namespace to enable server side ad tracking

--- a/ConvivaTestApp/src/androidTest/java/com/bitmovin/analytics/conviva/testapp/MetricReportingTests.kt
+++ b/ConvivaTestApp/src/androidTest/java/com/bitmovin/analytics/conviva/testapp/MetricReportingTests.kt
@@ -1,0 +1,99 @@
+package com.bitmovin.analytics.conviva.testapp
+
+import android.os.Handler
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.bitmovin.analytics.conviva.ConvivaAnalyticsIntegration
+import com.bitmovin.analytics.conviva.ConvivaConfig
+import com.bitmovin.analytics.conviva.MetadataOverrides
+import com.bitmovin.analytics.conviva.testapp.framework.BITMOVIN_PLAYER_LICENSE_KEY
+import com.bitmovin.analytics.conviva.testapp.framework.CONVIVA_CUSTOMER_KEY
+import com.bitmovin.analytics.conviva.testapp.framework.CONVIVA_GATEWAY_URL
+import com.bitmovin.analytics.conviva.testapp.framework.Sources
+import com.bitmovin.analytics.conviva.testapp.framework.expectEvent
+import com.bitmovin.analytics.conviva.testapp.framework.postWaiting
+import com.bitmovin.player.api.PlaybackConfig
+import com.bitmovin.player.api.Player
+import com.bitmovin.player.api.PlayerConfig
+import com.bitmovin.player.api.analytics.AnalyticsPlayerConfig
+import com.bitmovin.player.api.event.PlayerEvent
+import com.bitmovin.player.api.network.HttpRequestType
+import com.bitmovin.player.api.network.NetworkConfig
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.util.concurrent.CompletableFuture
+
+/**
+ * This test class does not verify any specific behavior, but rather can be used to validate the
+ * integration against the [Conviva Touchstone integration test tool](https://touchstone.conviva.com/).
+ */
+@RunWith(AndroidJUnit4::class)
+class MetricReportingTests {
+    /**
+     * Plays the first 5 seconds of a stream with a attached [ConvivaAnalyticsIntegration].
+     * Additionally injects average bitrate to the HLS manifest in order to report it.
+     */
+    @Test
+    fun reports_average_bitrate_and_peak_bitrate() {
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        val mainHandler = Handler(context.mainLooper)
+        val player = mainHandler.postWaiting {
+            val player = Player(
+                context,
+                PlayerConfig(
+                    key = BITMOVIN_PLAYER_LICENSE_KEY,
+                    playbackConfig = PlaybackConfig(
+                        isAutoplayEnabled = true,
+                    ),
+                    networkConfig = NetworkConfig(preprocessHttpResponseCallback = { type, response ->
+                        if (type != HttpRequestType.ManifestHlsMaster) {
+                            return@NetworkConfig null
+                        }
+                        val body = response.body.decodeToString()
+
+                        val regex = "BANDWIDTH=([0-9]+),".toRegex()
+                        val newBody = regex.replace(body) {
+                            val bandwidth = it.groups[1]!!.value.toInt()
+                            "BANDWIDTH=${bandwidth},AVERAGE-BANDWIDTH=${bandwidth - 100_000},"
+                        }
+
+                        CompletableFuture.completedFuture(response.copy(body = newBody.encodeToByteArray()))
+                    })
+                ),
+                analyticsConfig = AnalyticsPlayerConfig.Disabled,
+            )
+            val convivaAnalyticsIntegration = ConvivaAnalyticsIntegration(
+                player,
+                CONVIVA_CUSTOMER_KEY,
+                context,
+                ConvivaConfig().apply {
+                    isDebugLoggingEnabled = true
+                    gatewayUrl = CONVIVA_GATEWAY_URL
+                },
+            )
+
+            convivaAnalyticsIntegration.updateContentMetadata(
+                MetadataOverrides()
+                    .apply {
+                        applicationName = "Bitmovin Android Conviva integration example app"
+                        viewerId = "testViewerId"
+                    }
+            )
+            player
+        }
+
+        mainHandler.postWaiting { player.load(Sources.Hls.basic) }
+        player.expectEvent<PlayerEvent.TimeChanged> { it.time > 5.0 }
+
+        // pause player for a second and resume playback
+        mainHandler.postWaiting { player.pause() }
+        runBlocking { delay(1000) }
+        mainHandler.postWaiting { player.play() }
+        runBlocking { delay(1000) }
+
+        mainHandler.postWaiting { player.destroy() }
+        runBlocking { delay(1000) }
+    }
+}

--- a/ConvivaTestApp/src/androidTest/java/com/bitmovin/analytics/conviva/testapp/framework/Sources.kt
+++ b/ConvivaTestApp/src/androidTest/java/com/bitmovin/analytics/conviva/testapp/framework/Sources.kt
@@ -15,4 +15,12 @@ object Sources {
                 title = "Art of Motion Test Stream",
         )
     }
+
+    object Hls {
+        val basic = SourceConfig(
+            url = "https://bitmovin-a.akamaihd.net/content/MI201109210084_1/m3u8s/f08e80da-bf1d-4e3d-8899-f0f6155f6efa.m3u8",
+            type = SourceType.Hls,
+            title = "Art of Motion Test Stream",
+        )
+    }
 }

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ And these lines to your main project
 ```
 dependencies {
   implementation 'com.conviva.sdk:conviva-core-sdk:4.0.37' // <-- conviva sdk
-  implementation 'com.bitmovin.analytics:conviva:2.5.0'
+  implementation 'com.bitmovin.analytics:conviva:2.6.0'
 }
 ```
 

--- a/conviva/build.gradle
+++ b/conviva/build.gradle
@@ -5,7 +5,7 @@ apply plugin: 'kotlin-android'
 apply from: "../bitmovinpropertiesloader.gradle"
 
 def packageName = 'com.bitmovin.analytics'
-def libraryVersion = '2.5.0'
+def libraryVersion = '2.6.0'
 
 android {
     namespace 'com.bitmovin.analytics.conviva'

--- a/conviva/src/main/java/com/bitmovin/analytics/conviva/ssai/DefaultPlaybackInfoProvider.java
+++ b/conviva/src/main/java/com/bitmovin/analytics/conviva/ssai/DefaultPlaybackInfoProvider.java
@@ -32,8 +32,11 @@ public class DefaultPlaybackInfoProvider implements PlaybackInfoProvider {
         VideoQuality playbackVideoData = player.getPlaybackVideoData();
         if (playbackVideoData != null) {
             videoData.put(ConvivaSdkConstants.PLAYBACK.RESOLUTION, new Object[]{playbackVideoData.getWidth(), playbackVideoData.getHeight()});
-            videoData.put(ConvivaSdkConstants.PLAYBACK.BITRATE, new Object[]{playbackVideoData.getBitrate() / 1000});
-            int averageBitrate = playbackVideoData.getAverageBitrate();
+            final int peakBitrate = playbackVideoData.getPeakBitrate();
+            if (peakBitrate != VideoQuality.BITRATE_NO_VALUE) {
+                videoData.put(ConvivaSdkConstants.PLAYBACK.BITRATE, new Object[]{peakBitrate / 1000});
+            }
+            final int averageBitrate = playbackVideoData.getAverageBitrate();
             if (averageBitrate != VideoQuality.BITRATE_NO_VALUE) {
                 videoData.put(ConvivaSdkConstants.PLAYBACK.AVG_BITRATE, new Object[]{averageBitrate / 1000});
             }

--- a/conviva/src/main/java/com/bitmovin/analytics/conviva/ssai/DefaultPlaybackInfoProvider.java
+++ b/conviva/src/main/java/com/bitmovin/analytics/conviva/ssai/DefaultPlaybackInfoProvider.java
@@ -33,6 +33,10 @@ public class DefaultPlaybackInfoProvider implements PlaybackInfoProvider {
         if (playbackVideoData != null) {
             videoData.put(ConvivaSdkConstants.PLAYBACK.RESOLUTION, new Object[]{playbackVideoData.getWidth(), playbackVideoData.getHeight()});
             videoData.put(ConvivaSdkConstants.PLAYBACK.BITRATE, new Object[]{playbackVideoData.getBitrate() / 1000});
+            int averageBitrate = playbackVideoData.getAverageBitrate();
+            if (averageBitrate != VideoQuality.BITRATE_NO_VALUE) {
+                videoData.put(ConvivaSdkConstants.PLAYBACK.AVG_BITRATE, new Object[]{averageBitrate / 1000});
+            }
             videoData.put(ConvivaSdkConstants.PLAYBACK.RENDERED_FRAMERATE, new Object[]{Math.round(playbackVideoData.getFrameRate())});
         }
         return videoData;

--- a/conviva/src/test/kotlin/com/bitmovin/analytics/conviva/ConvivaAnalyticsIntegrationTest.kt
+++ b/conviva/src/test/kotlin/com/bitmovin/analytics/conviva/ConvivaAnalyticsIntegrationTest.kt
@@ -10,6 +10,7 @@ import com.bitmovin.player.api.event.Event
 import com.bitmovin.player.api.event.EventListener
 import com.bitmovin.player.api.event.PlayerEvent
 import com.bitmovin.player.api.event.SourceEvent
+import com.bitmovin.player.api.media.Quality
 import com.bitmovin.player.api.media.video.quality.VideoQuality
 import com.conviva.sdk.ConvivaAdAnalytics
 import com.conviva.sdk.ConvivaSdkConstants
@@ -126,6 +127,35 @@ class ConvivaAnalyticsIntegrationTest {
 
         verify { adAnalytics.reportAdMetric(ConvivaSdkConstants.PLAYBACK.BITRATE, 2) }
         verify { adAnalytics.reportAdMetric(ConvivaSdkConstants.PLAYBACK.AVG_BITRATE, 1) }
+        verify { adAnalytics.reportAdMetric(ConvivaSdkConstants.PLAYBACK.RESOLUTION, 400, 300) }
+        verify { adAnalytics.reportAdMetric(ConvivaSdkConstants.PLAYBACK.RENDERED_FRAMERATE, 10) }
+    }
+
+    @Test
+    fun `does not report bitrate, if not available`() {
+        every { ssaiApi.isAdBreakActive } returns true
+        Quality.Companion.BITRATE_NO_VALUE
+        val newVideoQuality = VideoQuality(
+            id = "id",
+            label = "label",
+            bitrate = Quality.Companion.BITRATE_NO_VALUE,
+            averageBitrate = Quality.Companion.BITRATE_NO_VALUE,
+            peakBitrate = Quality.Companion.BITRATE_NO_VALUE,
+            codec = "codec",
+            frameRate = 10.3F,
+            width = 400,
+            height = 300,
+        )
+        every { mockedPlayer.playbackVideoData } returns newVideoQuality
+
+        player.listeners[PlayerEvent.VideoPlaybackQualityChanged::class]?.forEach { onEvent ->
+            onEvent(PlayerEvent.VideoPlaybackQualityChanged(null, newVideoQuality))
+        }
+
+        verify(exactly = 0) {
+            adAnalytics.reportAdMetric(ConvivaSdkConstants.PLAYBACK.BITRATE, any())
+            adAnalytics.reportAdMetric(ConvivaSdkConstants.PLAYBACK.AVG_BITRATE, any())
+        }
         verify { adAnalytics.reportAdMetric(ConvivaSdkConstants.PLAYBACK.RESOLUTION, 400, 300) }
         verify { adAnalytics.reportAdMetric(ConvivaSdkConstants.PLAYBACK.RENDERED_FRAMERATE, 10) }
     }

--- a/conviva/src/test/kotlin/com/bitmovin/analytics/conviva/ConvivaAnalyticsIntegrationTest.kt
+++ b/conviva/src/test/kotlin/com/bitmovin/analytics/conviva/ConvivaAnalyticsIntegrationTest.kt
@@ -110,7 +110,9 @@ class ConvivaAnalyticsIntegrationTest {
         val newVideoQuality = VideoQuality(
                 id = "id",
                 label = "label",
-                bitrate = 1000,
+                bitrate = 2000,
+                averageBitrate = 1000,
+                peakBitrate = 2000,
                 codec = "codec",
                 frameRate = 10.3F,
                 width = 400,
@@ -122,7 +124,8 @@ class ConvivaAnalyticsIntegrationTest {
             onEvent(PlayerEvent.VideoPlaybackQualityChanged(null, newVideoQuality))
         }
 
-        verify { adAnalytics.reportAdMetric(ConvivaSdkConstants.PLAYBACK.BITRATE, 1) }
+        verify { adAnalytics.reportAdMetric(ConvivaSdkConstants.PLAYBACK.BITRATE, 2) }
+        verify { adAnalytics.reportAdMetric(ConvivaSdkConstants.PLAYBACK.AVG_BITRATE, 1) }
         verify { adAnalytics.reportAdMetric(ConvivaSdkConstants.PLAYBACK.RESOLUTION, 400, 300) }
         verify { adAnalytics.reportAdMetric(ConvivaSdkConstants.PLAYBACK.RENDERED_FRAMERATE, 10) }
     }

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,5 +1,5 @@
 ext {
-    bitmovinPlayerVersion = '3.71.0'
+    bitmovinPlayerVersion = '3.78.2'
     googleImaSdk = '3.31.0'
     googlePlayAdsIdentifier = '18.0.1'
 


### PR DESCRIPTION
With the latest bitmovin player release, we added support for the `Quality.averageBitrate`.
This PR and the average bitrate to the reported video playback metrics

## Changes
- Update bitmovin player to `3.78.2`
- Add `AVG_BITRATE` metric
- Add test to verify the flag (has to be manually checked on the _Conviva Touchstone_)
- Add changelog entry