### PR TITLE
Remove unintentionally public initializers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
-### Fixed
-- Remove unintentionally public initializers from `ConvivaAnalyticsIntegration` which were not intended to be public and only meant for testing
+### Removed
+- Unintentionally public initializers from `ConvivaAnalyticsIntegration` which were not intended to be public and only meant for testing
 
 ## 2.6.0 - 2024-08-13
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+### Fixed
+- Remove unintentionally public initializers from `ConvivaAnalyticsIntegration` which were not intended to be public and only meant for testing
 
 ## 2.6.0 - 2024-08-13
 ### Added

--- a/conviva/src/main/java/com/bitmovin/analytics/conviva/ConvivaAnalyticsIntegration.java
+++ b/conviva/src/main/java/com/bitmovin/analytics/conviva/ConvivaAnalyticsIntegration.java
@@ -66,9 +66,6 @@ public class ConvivaAnalyticsIntegration {
         this(player, customerKey, context, config, null, null, null);
     }
 
-    /**
-     * For testing purposes only.
-     */
     ConvivaAnalyticsIntegration(
         Player player,
         String customerKey,

--- a/conviva/src/main/java/com/bitmovin/analytics/conviva/ConvivaAnalyticsIntegration.java
+++ b/conviva/src/main/java/com/bitmovin/analytics/conviva/ConvivaAnalyticsIntegration.java
@@ -57,42 +57,26 @@ public class ConvivaAnalyticsIntegration {
         this(player, customerKey, context, new ConvivaConfig());
     }
 
-    public ConvivaAnalyticsIntegration(Player player,
-                                       String customerKey,
-                                       Context context,
-                                       ConvivaConfig config) {
-        this(player, customerKey, context, config, null);
-    }
-
-    public ConvivaAnalyticsIntegration(Player player,
-                                       String customerKey,
-                                       Context context,
-                                       ConvivaConfig config,
-                                       ConvivaVideoAnalytics videoAnalytics
+    public ConvivaAnalyticsIntegration(
+        Player player,
+        String customerKey,
+        Context context,
+        ConvivaConfig config
     ) {
-        this(player, customerKey, context, config, videoAnalytics, null);
-    }
-
-    public ConvivaAnalyticsIntegration(Player player,
-                                       String customerKey,
-                                       Context context,
-                                       ConvivaConfig config,
-                                       ConvivaVideoAnalytics videoAnalytics,
-                                       ConvivaAdAnalytics adAnalytics
-    ) {
-        this(player, customerKey, context, config, videoAnalytics, adAnalytics, null);
+        this(player, customerKey, context, config, null, null, null);
     }
 
     /**
      * For testing purposes only.
      */
-    ConvivaAnalyticsIntegration(Player player,
-                                String customerKey,
-                                Context context,
-                                ConvivaConfig config,
-                                ConvivaVideoAnalytics videoAnalytics,
-                                ConvivaAdAnalytics adAnalytics,
-                                DefaultSsaiApi ssai
+    ConvivaAnalyticsIntegration(
+        Player player,
+        String customerKey,
+        Context context,
+        ConvivaConfig config,
+        ConvivaVideoAnalytics videoAnalytics,
+        ConvivaAdAnalytics adAnalytics,
+        DefaultSsaiApi ssai
     ) {
         this.bitmovinPlayer = player;
         this.playerHelper = new BitmovinPlayerHelper(player);


### PR DESCRIPTION
## Description
### Problem
While working on adding new constructor overloads we figured out that there are constructors public which shouldn't be public.

### Changes
Removing those initializers.

### Checklist
- [x] I added an update to `CHANGELOG.md` file
- [x] I ran all the tests in the project and they succeed