### PR TITLE
Do not send warning events to conviva outside of active conviva session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- Potential integration error shown in Touchstone if the player emits a warning outside of an active Conviva session
+
+### Changed
+- Updated Bitmovin Player to `3.81.0`
 
 ## 2.6.0 - 2024-08-28
 ### Added

--- a/ConvivaTestApp/src/androidTest/java/com/bitmovin/analytics/conviva/testapp/WarningTests.kt
+++ b/ConvivaTestApp/src/androidTest/java/com/bitmovin/analytics/conviva/testapp/WarningTests.kt
@@ -1,0 +1,84 @@
+package com.bitmovin.analytics.conviva.testapp
+
+import android.os.Handler
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.bitmovin.analytics.conviva.ConvivaAnalyticsIntegration
+import com.bitmovin.analytics.conviva.ConvivaConfig
+import com.bitmovin.analytics.conviva.MetadataOverrides
+import com.bitmovin.analytics.conviva.testapp.framework.BITMOVIN_PLAYER_LICENSE_KEY
+import com.bitmovin.analytics.conviva.testapp.framework.CONVIVA_CUSTOMER_KEY
+import com.bitmovin.analytics.conviva.testapp.framework.CONVIVA_GATEWAY_URL
+import com.bitmovin.analytics.conviva.testapp.framework.Sources
+import com.bitmovin.analytics.conviva.testapp.framework.callAndExpectEvent
+import com.bitmovin.analytics.conviva.testapp.framework.expectEvent
+import com.bitmovin.analytics.conviva.testapp.framework.postWaiting
+import com.bitmovin.player.api.PlaybackConfig
+import com.bitmovin.player.api.Player
+import com.bitmovin.player.api.PlayerConfig
+import com.bitmovin.player.api.analytics.AnalyticsPlayerConfig
+import com.bitmovin.player.api.event.PlayerEvent
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * This test class does not verify any specific behavior, but rather can be used to validate the
+ * integration against the [Conviva Touchstone integration test tool](https://touchstone.conviva.com/).
+ */
+@RunWith(AndroidJUnit4::class)
+class WarningTests {
+    /**
+     * Triggers a warning outside of the active conviva session. No integration error must be
+     * shown in Touchstone.
+     */
+    @Test
+    fun warning_outside_of_active_conviva_session_does_not_cause_integration_error() {
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        val mainHandler = Handler(context.mainLooper)
+        val player = mainHandler.postWaiting {
+            Player(
+                    context,
+                    PlayerConfig(
+                            key = BITMOVIN_PLAYER_LICENSE_KEY,
+                            playbackConfig = PlaybackConfig(
+                                    isAutoplayEnabled = true,
+                            ),
+                    ),
+                    analyticsConfig = AnalyticsPlayerConfig.Disabled,
+            )
+        }
+        mainHandler.postWaiting {
+            val conviva = ConvivaAnalyticsIntegration(
+                    player,
+                    CONVIVA_CUSTOMER_KEY,
+                    context,
+                    ConvivaConfig().apply {
+                        isDebugLoggingEnabled = true
+                        gatewayUrl = CONVIVA_GATEWAY_URL
+                    },
+            )
+            conviva.updateContentMetadata(
+                    MetadataOverrides().apply {
+                        applicationName = "Bitmovin Android Conviva integration test app"
+                        viewerId = "testViewerId"
+                        assetName = "warning_outside_of_active_conviva_session_does_not_cause_integration_error"
+                    }
+            )
+        }
+
+        mainHandler.postWaiting {
+            player.load(Sources.Dash.basic)
+        }
+        player.expectEvent<PlayerEvent.TimeChanged> { it.time > 10.0 }
+        mainHandler.postWaiting {
+            player.unload() // Unloading the player ends the active conviva session
+        }
+        runBlocking { delay(500) } // Give conviva some time to end the session
+        player.callAndExpectEvent<PlayerEvent.Warning>(block = {
+            player.play() // Calling "play" outside of an active playback session triggers a warning
+        })
+        runBlocking { delay(500) } // Give Conviva some time to report the event
+    }
+}

--- a/conviva/src/main/java/com/bitmovin/analytics/conviva/ConvivaAnalyticsIntegration.java
+++ b/conviva/src/main/java/com/bitmovin/analytics/conviva/ConvivaAnalyticsIntegration.java
@@ -588,6 +588,10 @@ public class ConvivaAnalyticsIntegration {
     private final EventListener<PlayerEvent.Warning> onPlayerWarningListener = new EventListener<PlayerEvent.Warning>() {
         @Override
         public void onEvent(PlayerEvent.Warning warningEvent) {
+            if (!isSessionActive) {
+                Log.d(TAG, "[Player Event] Warning outside of active conviva session. Ignoring.");
+                return;
+            }
             Log.d(TAG, "[Player Event] Warning");
             String message = String.format("%s - %s", warningEvent.getCode(), warningEvent.getMessage());
             convivaVideoAnalytics.reportPlaybackError(message, ConvivaSdkConstants.ErrorSeverity.WARNING);
@@ -597,6 +601,10 @@ public class ConvivaAnalyticsIntegration {
     private final EventListener<SourceEvent.Warning> onSourceWarningListener = new EventListener<SourceEvent.Warning>() {
         @Override
         public void onEvent(SourceEvent.Warning warningEvent) {
+            if (!isSessionActive) {
+                Log.d(TAG, "[Source Event] Warning outside of active conviva session. Ignoring.");
+                return;
+            }
             Log.d(TAG, "[Source Event] Warning");
             String message = String.format("%s - %s", warningEvent.getCode(), warningEvent.getMessage());
             convivaVideoAnalytics.reportPlaybackError(message, ConvivaSdkConstants.ErrorSeverity.WARNING);

--- a/conviva/src/test/kotlin/com/bitmovin/analytics/conviva/ConvivaAnalyticsIntegrationTest.kt
+++ b/conviva/src/test/kotlin/com/bitmovin/analytics/conviva/ConvivaAnalyticsIntegrationTest.kt
@@ -8,6 +8,8 @@ import com.bitmovin.analytics.conviva.helper.unmockLogging
 import com.bitmovin.analytics.conviva.ssai.DefaultSsaiApi
 import com.bitmovin.player.api.Player
 import com.bitmovin.player.api.deficiency.PlayerErrorCode
+import com.bitmovin.player.api.deficiency.PlayerWarningCode
+import com.bitmovin.player.api.deficiency.SourceWarningCode
 import com.bitmovin.player.api.event.PlayerEvent
 import com.bitmovin.player.api.event.SourceEvent
 import com.bitmovin.player.api.media.Quality
@@ -166,6 +168,22 @@ class ConvivaAnalyticsIntegrationTest {
         }
         verify { adAnalytics.reportAdMetric(ConvivaSdkConstants.PLAYBACK.RESOLUTION, 400, 300) }
         verify { adAnalytics.reportAdMetric(ConvivaSdkConstants.PLAYBACK.RENDERED_FRAMERATE, 10) }
+    }
+
+    @Test
+    fun `does not report a playback error when receiving a player warning event without active conviva session`() {
+        player.listeners[PlayerEvent.Warning::class]?.forEach { onEvent ->
+            onEvent(PlayerEvent.Warning(PlayerWarningCode.General, "warning"))
+        }
+        verify(exactly = 0) { videoAnalytics.reportPlaybackError(any(), any()) }
+    }
+
+    @Test
+    fun `does not report a playback error when receiving a source warning event without active conviva session`() {
+        player.listeners[SourceEvent.Warning::class]?.forEach { onEvent ->
+            onEvent(SourceEvent.Warning(SourceWarningCode.General, "warning"))
+        }
+        verify(exactly = 0) { videoAnalytics.reportPlaybackError(any(), any()) }
     }
 
     companion object {

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,5 +1,5 @@
 ext {
-    bitmovinPlayerVersion = '3.78.2'
+    bitmovinPlayerVersion = '3.81.0'
     googleImaSdk = '3.31.0'
     googlePlayAdsIdentifier = '18.0.1'
 


### PR DESCRIPTION
## Problem
`PlayerEvent.Warning` and `SourceEvent.Warning` can happen outside of an active Conviva session. This can result in invalid reporting.

## Changes
- Only relay warning events to Conviva if there is an active Conviva session
- Update Bitmovin Player to the latest version 