### PR TITLE
Fix vmap mid roll ad position reporting

### DIFF
--- a/ConvivaTestApp/src/androidTest/java/com/bitmovin/analytics/conviva/testapp/framework/Sources.kt
+++ b/ConvivaTestApp/src/androidTest/java/com/bitmovin/analytics/conviva/testapp/framework/Sources.kt
@@ -6,6 +6,10 @@ import com.bitmovin.player.api.source.SourceType
 object Sources {
     object Ads {
         const val VMAP_PREROLL_SINGLE_TAG = "https://pubads.g.doubleclick.net/gampad/ads?sz=640x480&iu=/124319096/external/ad_rule_samples&ciu_szs=300x250&ad_rule=1&impl=s&gdfp_req=1&env=vp&output=vmap&unviewed_position_start=1&cust_params=deployment%3Ddevsite%26sample_ar%3Dpreonly&cmsid=496&vid=short_onecue&correlator="
+
+        const val VMAP_PREROLL_MIDROLL_POSTROLL_TAG = "https://pubads.g.doubleclick.net/gampad/ads?iu=/21775744923/external/vmap_ad_samples&sz=640x480&cust_params=sample_ar%3Dpremidpost&ciu_szs=300x250&gdfp_req=1&ad_rule=1&output=vmap&unviewed_position_start=1&env=vp&impl=s&cmsid=496&vid=short_onecue&correlator="
+
+        const val VAST_SINGLE_LINEAR_INLINE = "https://pubads.g.doubleclick.net/gampad/ads?iu=/21775744923/external/single_ad_samples&sz=640x480&cust_params=sample_ct%3Dlinear&ciu_szs=300x250%2C728x90&gdfp_req=1&output=vast&unviewed_position_start=1&env=vp&impl=s&correlator="
     }
 
     object Dash {
@@ -13,6 +17,12 @@ object Sources {
                 url = "https://bitmovin-a.akamaihd.net/content/MI201109210084_1/mpds/f08e80da-bf1d-4e3d-8899-f0f6155f6efa.mpd",
                 type = SourceType.Dash,
                 title = "Art of Motion Test Stream",
+        )
+
+        val basicLive = SourceConfig(
+                url = "https://livesim.dashif.org/livesim2/testpic_2s/Manifest.mpd",
+                type = SourceType.Dash,
+                title = "DASH livesim Live Stream",
         )
     }
 

--- a/conviva/src/main/java/com/bitmovin/analytics/conviva/ConvivaAnalyticsIntegration.java
+++ b/conviva/src/main/java/com/bitmovin/analytics/conviva/ConvivaAnalyticsIntegration.java
@@ -59,6 +59,8 @@ public class ConvivaAnalyticsIntegration {
 
     private Boolean isBumper = false;
     private Boolean isBackgrounded = false;
+    @Nullable
+    private AdBreak activeAdBreak;
 
     public ConvivaAnalyticsIntegration(String customerKey, Context context) {
         this(
@@ -725,8 +727,6 @@ public class ConvivaAnalyticsIntegration {
 
     // region Ad events
 
-    @Nullable
-    private AdBreak activeAdBreak;
     private final EventListener<PlayerEvent.AdBreakStarted> onAdBreakStarted = new EventListener<PlayerEvent.AdBreakStarted>() {
         @Override
         public void onEvent(PlayerEvent.AdBreakStarted adBreakStarted) {

--- a/conviva/src/test/kotlin/com/bitmovin/analytics/conviva/ConvivaAnalyticsIntegrationTest.kt
+++ b/conviva/src/test/kotlin/com/bitmovin/analytics/conviva/ConvivaAnalyticsIntegrationTest.kt
@@ -199,7 +199,7 @@ class ConvivaAnalyticsIntegrationTest {
         }
 
         verify { videoAnalytics.reportAdBreakStarted(any(), any()) }
-        player.listeners[PlayerEvent.AdStarted::class]?.forEach { it(TEST_AD) }
+        player.listeners[PlayerEvent.AdStarted::class]?.forEach { it(TEST_AD_STARTED_EVENT) }
         verify {
             adAnalytics.reportAdStarted(match { it["c3.ad.position"] == AdPosition.MIDROLL })
         }
@@ -209,7 +209,7 @@ class ConvivaAnalyticsIntegrationTest {
         }
 
         verify { videoAnalytics.reportAdBreakStarted(any(), any()) }
-        player.listeners[PlayerEvent.AdStarted::class]?.forEach { it(TEST_AD) }
+        player.listeners[PlayerEvent.AdStarted::class]?.forEach { it(TEST_AD_STARTED_EVENT) }
         verify {
             adAnalytics.reportAdStarted(match { it["c3.ad.position"] == AdPosition.PREROLL })
         }
@@ -266,7 +266,7 @@ private val attachedPlayerEvents = listOf(
         SourceEvent.Warning::class,
 )
 
-private val TEST_AD = PlayerEvent.AdStarted(
+private val TEST_AD_STARTED_EVENT = PlayerEvent.AdStarted(
         clientType = AdSourceType.Ima,
         clickThroughUrl = "clickThroughUrl",
         duration = 10.0,

--- a/conviva/src/test/kotlin/com/bitmovin/analytics/conviva/ConvivaAnalyticsIntegrationTest.kt
+++ b/conviva/src/test/kotlin/com/bitmovin/analytics/conviva/ConvivaAnalyticsIntegrationTest.kt
@@ -204,7 +204,7 @@ class ConvivaAnalyticsIntegrationTest {
         }
 
         player.listeners[PlayerEvent.AdBreakStarted::class]?.forEach {
-            it(createAdBreakStartedEvent(00.0))
+            it(createAdBreakStartedEvent(0.0))
         }
 
         verify { videoAnalytics.reportAdBreakStarted(any(), any()) }

--- a/conviva/src/test/kotlin/com/bitmovin/analytics/conviva/ConvivaAnalyticsIntegrationTest.kt
+++ b/conviva/src/test/kotlin/com/bitmovin/analytics/conviva/ConvivaAnalyticsIntegrationTest.kt
@@ -193,7 +193,6 @@ class ConvivaAnalyticsIntegrationTest {
 
     @Test
     fun `reports CSAI ad position based on last ad break schedule time`() {
-
         player.listeners[PlayerEvent.AdBreakStarted::class]?.forEach {
             it(createAdBreakStartedEvent(10.0))
         }

--- a/conviva/src/test/kotlin/com/bitmovin/analytics/conviva/ConvivaAnalyticsIntegrationTest.kt
+++ b/conviva/src/test/kotlin/com/bitmovin/analytics/conviva/ConvivaAnalyticsIntegrationTest.kt
@@ -273,40 +273,14 @@ private val TEST_AD_STARTED_EVENT = PlayerEvent.AdStarted(
         timeOffset = 10.0,
         position = "0.0",
         skipOffset = 10.0,
-        ad = object : Ad {
-            override val clickThroughUrl: String?
-                get() = "clickThroughUrl"
-            override val data: AdData?
-                get() = null
-            override val height: Int
-                get() = 100
-            override val id: String?
-                get() = null
-            override val isLinear: Boolean
-                get() = true
-            override val mediaFileUrl: String?
-                get() = null
-            override val width: Int
-                get() = 200
-
-            override fun clickThroughUrlOpened() {}
-        },
+        ad = mockk(relaxed = true),
         indexInQueue = 0,
 )
 
 private fun createAdBreakStartedEvent(scheduleTime: Double): PlayerEvent.AdBreakStarted {
     val adBreakStarted = PlayerEvent.AdBreakStarted(
-        adBreak = object : AdBreak {
-            override val ads: List<Ad>
-                get() = emptyList()
-            override val id: String
-                get() = ""
-            override val replaceContentDuration: Double?
-                get() = null
-            override val scheduleTime: Double
-                get() {
-                    return scheduleTime
-                }
+        adBreak = mockk {
+            every { this@mockk.scheduleTime } returns scheduleTime
         }
     )
     return adBreakStarted


### PR DESCRIPTION
## Problem
Ad position reporting for client side ad insertion with VMAP and Google IMA ads integration was reporting wrong ad position for mid- and post-roll ads.

## Changes
As the timing information on the ad is not reported correctly for VMAP ads (tracked internally), we take the correct time from the current active ad break. This is in line with the tacking on web.