### PR TITLE
Added the default value for isSlate field per Conviva documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Added
+- default value of `false` for `c3.ad.isSlate` per Conviva Custom Ad Manager integration docs
+
 ## 2.7.1 - 2024-09-24
 ### Fixed
 - Reporting wrong ad position for mid-roll VMAP ads

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 
 ### Added
-- default value of `false` for `c3.ad.isSlate` per Conviva Custom Ad Manager integration docs
+- Default value of `false` for `c3.ad.isSlate` for client side ad insertion per Conviva Custom Ad Manager integration docs
 
 ## 2.7.1 - 2024-09-24
 ### Fixed

--- a/conviva/src/main/java/com/bitmovin/analytics/conviva/ConvivaAnalyticsIntegration.java
+++ b/conviva/src/main/java/com/bitmovin/analytics/conviva/ConvivaAnalyticsIntegration.java
@@ -794,6 +794,9 @@ public class ConvivaAnalyticsIntegration {
             adInfo.put(ConvivaSdkConstants.FRAMEWORK_VERSION, Player.getSdkVersion());
         }
 
+        // default value for isSlate is false for Custom Ad Manager integration
+        adInfo.put("c3.ad.isSlate", "false");
+
         double scheduleTime;
         if (activeAdBreak != null) {
             scheduleTime = activeAdBreak.getScheduleTime();


### PR DESCRIPTION
added a default value of false for c3.ad.isSlate in `adStartedToAdInfo` method.

Conviva documentation reference - https://pulse.conviva.com/learning-center/content/sensor_developer_center/sensor_integration/android/android_quick_integration.htm

Please see highlighted text in screenshot.
<img width="1042" alt="Screenshot 2024-10-22 at 5 37 12 PM" src="https://github.com/user-attachments/assets/38352586-a07d-4f19-89a6-f196a3fe0f50">
