### PR TITLE
Feature/optional auto end session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - Support for reporting the stack trace in case of error events, if provided by the player
 - New `ConvivaAnalyticsIntegration.setAutoEndSession` to not end Conviva session automatically from certain player events if set to false (true by default).
+- New `ConvivaAnalyticsIntegration.reportPlaybackStalled` to report a stalled event to Conviva
 
 ## 2.7.2 - 2024-10-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 - Support for reporting the stack trace in case of error events, if provided by the player
+- New `ConvivaAnalyticsIntegration.setAutoEndSession` to not end Conviva session automatically from certain player events if set to false (true by default).
 
 ## 2.7.2 - 2024-10-28
 

--- a/conviva/src/test/kotlin/com/bitmovin/analytics/conviva/ConvivaAnalyticsIntegrationTest.kt
+++ b/conviva/src/test/kotlin/com/bitmovin/analytics/conviva/ConvivaAnalyticsIntegrationTest.kt
@@ -66,6 +66,8 @@ class ConvivaAnalyticsIntegrationTest {
                 adAnalytics,
                 ssaiApi,
         )
+        convivaAnalyticsIntegration.initializeSession()
+        clearMocks(videoAnalytics, answers = true)
     }
 
     @After
@@ -177,6 +179,8 @@ class ConvivaAnalyticsIntegrationTest {
 
     @Test
     fun `does not report a playback error when receiving a player warning event without active conviva session`() {
+        convivaAnalyticsIntegration.endSession()
+
         player.listeners[PlayerEvent.Warning::class]?.forEach { onEvent ->
             onEvent(PlayerEvent.Warning(PlayerWarningCode.General, "warning"))
         }
@@ -185,10 +189,24 @@ class ConvivaAnalyticsIntegrationTest {
 
     @Test
     fun `does not report a playback error when receiving a source warning event without active conviva session`() {
+        convivaAnalyticsIntegration.endSession()
+
         player.listeners[SourceEvent.Warning::class]?.forEach { onEvent ->
             onEvent(SourceEvent.Warning(SourceWarningCode.General, "warning"))
         }
         verify(exactly = 0) { videoAnalytics.reportPlaybackError(any(), any()) }
+    }
+
+    @Test
+    fun `does not report a playback stalled without active conviva session`() {
+        convivaAnalyticsIntegration.reportPlaybackStalled()
+        verify(exactly = 1) { videoAnalytics.reportPlaybackMetric(any(), any()) }
+
+        convivaAnalyticsIntegration.endSession()
+        clearMocks(videoAnalytics, answers = true)
+
+        convivaAnalyticsIntegration.reportPlaybackStalled()
+        verify(exactly = 0) { videoAnalytics.reportPlaybackMetric(any(), any()) }
     }
 
     @Test


### PR DESCRIPTION
This PR will introduce a way to not end Conviva session from player events.   This allows the implementation of app specific constructs such as custom retries without Conviva repeatedly reporting VPF for each retry.