### PR TITLE
Use error codes in error reporting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - New `ConvivaAnalyticsIntegration.setAutoEndSession` to not end Conviva session automatically from certain player events if set to false (true by default).
 - New `ConvivaAnalyticsIntegration.reportPlaybackStalled` to report a stalled event to Conviva
 
+### Changed
+- Error reporting now uses the error code instead of the error name as prefix
+
 ## 2.7.2 - 2024-10-28
 
 ### Added

--- a/conviva/src/main/java/com/bitmovin/analytics/conviva/ConvivaAnalyticsIntegration.java
+++ b/conviva/src/main/java/com/bitmovin/analytics/conviva/ConvivaAnalyticsIntegration.java
@@ -600,15 +600,15 @@ public class ConvivaAnalyticsIntegration {
     };
 
     private final EventListener<PlayerEvent.Error> onPlayerErrorListener = event -> {
-        Log.d(TAG, "[Player Event] Error");
+        Log.d(TAG, "[Player Event] Error - " + event.getCode().getValue());
         customEvent(event); // In case of Error, report current stack trace if available
-        handleError(String.format("%s - %s", event.getCode(), event.getMessage()));
+        handleError(String.format("%s - %s", event.getCode().getValue(), event.getMessage()));
     };
 
     private final EventListener<SourceEvent.Error> onSourceErrorListener = event -> {
-        Log.d(TAG, "[Source Event] Error");
+        Log.d(TAG, "[Source Event] Error - " + event.getCode().getValue());
         customEvent(event); // In case of Error, report current stack trace if available
-        handleError(String.format("%s - %s", event.getCode(), event.getMessage()));
+        handleError(String.format("%s - %s", event.getCode().getValue(), event.getMessage()));
     };
 
     private void handleError(String message) {
@@ -627,7 +627,7 @@ public class ConvivaAnalyticsIntegration {
                 return;
             }
             Log.d(TAG, "[Player Event] Warning");
-            String message = String.format("%s - %s", warningEvent.getCode(), warningEvent.getMessage());
+            String message = String.format("%s - %s", warningEvent.getCode().getValue(), warningEvent.getMessage());
             convivaVideoAnalytics.reportPlaybackError(message, ConvivaSdkConstants.ErrorSeverity.WARNING);
         }
     };
@@ -640,7 +640,7 @@ public class ConvivaAnalyticsIntegration {
                 return;
             }
             Log.d(TAG, "[Source Event] Warning");
-            String message = String.format("%s - %s", warningEvent.getCode(), warningEvent.getMessage());
+            String message = String.format("%s - %s", warningEvent.getCode().getValue(), warningEvent.getMessage());
             convivaVideoAnalytics.reportPlaybackError(message, ConvivaSdkConstants.ErrorSeverity.WARNING);
         }
     };


### PR DESCRIPTION
## Description

When reporting playback errors, we build an error message based on the error code + its message. However, since the switch to Kotlin was made for the `ErrorCode`, it no longer reports the numeric value but instead reports the error name. This was unintentional, and this PR reverts to the error code.

### Changes
Using the errorCode numeric value when building the error message which is reported to conviva.